### PR TITLE
Add additional permissions needed for hosted zone lookup by name

### DIFF
--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -7,8 +7,9 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
   statement {
     actions = [
       "route53:ChangeResourceRecordSets",
-      "route53:ListResourceRecordSets",
       "route53:GetHostedZone",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
     ]
 
     resources = ["arn:aws:route53:::hostedzone/${aws_route53_zone.cyber_dhs_gov.id}"]
@@ -20,6 +21,14 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
     ]
 
     resources = ["arn:aws:route53:::change/*"]
+  }
+
+  statement {
+    actions = [
+      "route53:ListHostedZones"
+    ]
+
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds additional permissions that are needed when looking up the hosted zone by name.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This PR was needed due to the changes in https://github.com/cisagov/pca-teamserver-aws/pull/30.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
`terraform apply` was executed successfully in the `production` workspace.  Then, the code from https://github.com/cisagov/pca-teamserver-aws/pull/30 was used to successfully add a DNS record in this zone.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
