### PR TITLE
Automate domain verification and DKIM record generation

### DIFF
--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -1,19 +1,23 @@
 # ------------------------------------------------------------------------------
-# Resource records that support the DMARC application.
-# ------------------------------------------------------------------------------
-
-# ------------------------------------------------------------------------------
 # Evaluate expressions for use throughout this file.
 # ------------------------------------------------------------------------------
 locals {
   dmarc_domain_name = "dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
 }
 
+# ------------------------------------------------------------------------------
+# Generation of the domain identity token in SES.
+# ------------------------------------------------------------------------------
+
 resource "aws_ses_domain_identity" "dmarc_identity" {
   provider = aws.route53resourcechange
 
   domain = local.dmarc_domain_name
 }
+
+# ------------------------------------------------------------------------------
+# Resource records that support the DMARC application.
+# ------------------------------------------------------------------------------
 
 resource "aws_route53_record" "dmarc_MX" {
   provider = aws.route53resourcechange

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -15,6 +15,12 @@ resource "aws_ses_domain_identity" "dmarc_identity" {
   domain = local.dmarc_domain_name
 }
 
+resource "aws_ses_domain_dkim" "dmarc_dkim" {
+  provider = aws.route53resourcechange
+
+  domain = aws_ses_domain_identity.dmarc_identity.domain
+}
+
 # ------------------------------------------------------------------------------
 # Resource records that support the DMARC application.
 # ------------------------------------------------------------------------------
@@ -49,32 +55,13 @@ resource "aws_route53_record" "wildcard_report_dmarc_TXT" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
-resource "aws_route53_record" "dkim1_dmarc_CNAME" {
+resource "aws_route53_record" "dkim_dmarc_CNAME" {
   provider = aws.route53resourcechange
 
-  name    = "6na6lcj7onl5bco4ytfj4ud7p6t7kvtp._domainkey.${local.dmarc_domain_name}"
-  records = ["6na6lcj7onl5bco4ytfj4ud7p6t7kvtp.dkim.amazonses.com"]
-  ttl     = 1800
-  type    = "CNAME"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "dkim2_dmarc_CNAME" {
-  provider = aws.route53resourcechange
-
-  name    = "nsbndtrubsyckjqnb4wkv6xdkrqe3dk5._domainkey.${local.dmarc_domain_name}"
-  records = ["nsbndtrubsyckjqnb4wkv6xdkrqe3dk5.dkim.amazonses.com"]
-  ttl     = 1800
-  type    = "CNAME"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "dkim3_dmarc_CNAME" {
-  provider = aws.route53resourcechange
-
-  name    = "yhfkaco3ukhtbowt2bdvfz5czwuofitm._domainkey.${local.dmarc_domain_name}"
-  records = ["yhfkaco3ukhtbowt2bdvfz5czwuofitm.dkim.amazonses.com"]
-  ttl     = 1800
+  count   = 3
+  name    = "${element(aws_ses_domain_dkim.dmarc_dkim.dkim_tokens, count.index)}._domainkey.${local.dmarc_domain_name}"
+  records = ["${element(aws_ses_domain_dkim.dmarc_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  ttl     = "600"
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -2,10 +2,23 @@
 # Resource records that support the DMARC application.
 # ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
+# Evaluate expressions for use throughout this file.
+# ------------------------------------------------------------------------------
+locals {
+  dmarc_domain_name = "dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+}
+
+resource "aws_ses_domain_identity" "dmarc_identity" {
+  provider = aws.route53resourcechange
+
+  domain = local.dmarc_domain_name
+}
+
 resource "aws_route53_record" "dmarc_MX" {
   provider = aws.route53resourcechange
 
-  name    = "dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = local.dmarc_domain_name
   records = ["10 inbound-smtp.us-east-1.amazonaws.com"]
   ttl     = 1800
   type    = "MX"
@@ -15,8 +28,8 @@ resource "aws_route53_record" "dmarc_MX" {
 resource "aws_route53_record" "_amazonses_dmarc_TXT" {
   provider = aws.route53resourcechange
 
-  name    = "_amazonses.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["OHUkpPtvpdayRxxI15t6tGA38DHwt+JnJ1jpaAE4Sa8="]
+  name    = "_amazonses.${local.dmarc_domain_name}"
+  records = ["${aws_ses_domain_identity.dmarc_identity.verification_token}"]
   ttl     = 60
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
@@ -25,7 +38,7 @@ resource "aws_route53_record" "_amazonses_dmarc_TXT" {
 resource "aws_route53_record" "wildcard_report_dmarc_TXT" {
   provider = aws.route53resourcechange
 
-  name    = "*._report._dmarc.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = "*._report._dmarc.${local.dmarc_domain_name}"
   records = ["v=DMARC1"]
   ttl     = 300
   type    = "TXT"
@@ -35,7 +48,7 @@ resource "aws_route53_record" "wildcard_report_dmarc_TXT" {
 resource "aws_route53_record" "dkim1_dmarc_CNAME" {
   provider = aws.route53resourcechange
 
-  name    = "6na6lcj7onl5bco4ytfj4ud7p6t7kvtp._domainkey.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = "6na6lcj7onl5bco4ytfj4ud7p6t7kvtp._domainkey.${local.dmarc_domain_name}"
   records = ["6na6lcj7onl5bco4ytfj4ud7p6t7kvtp.dkim.amazonses.com"]
   ttl     = 1800
   type    = "CNAME"
@@ -45,7 +58,7 @@ resource "aws_route53_record" "dkim1_dmarc_CNAME" {
 resource "aws_route53_record" "dkim2_dmarc_CNAME" {
   provider = aws.route53resourcechange
 
-  name    = "nsbndtrubsyckjqnb4wkv6xdkrqe3dk5._domainkey.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = "nsbndtrubsyckjqnb4wkv6xdkrqe3dk5._domainkey.${local.dmarc_domain_name}"
   records = ["nsbndtrubsyckjqnb4wkv6xdkrqe3dk5.dkim.amazonses.com"]
   ttl     = 1800
   type    = "CNAME"
@@ -55,7 +68,7 @@ resource "aws_route53_record" "dkim2_dmarc_CNAME" {
 resource "aws_route53_record" "dkim3_dmarc_CNAME" {
   provider = aws.route53resourcechange
 
-  name    = "yhfkaco3ukhtbowt2bdvfz5czwuofitm._domainkey.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = "yhfkaco3ukhtbowt2bdvfz5czwuofitm._domainkey.${local.dmarc_domain_name}"
   records = ["yhfkaco3ukhtbowt2bdvfz5czwuofitm.dkim.amazonses.com"]
   ttl     = 1800
   type    = "CNAME"

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -16,7 +16,7 @@ resource "aws_route53_record" "_amazonses_dmarc_TXT" {
   provider = aws.route53resourcechange
 
   name    = "_amazonses.dmarc.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["CV4Ex6gYlJutTAnA8xkQa0hk3toSRuFvmibJ0sRiAWw="]
+  records = ["OHUkpPtvpdayRxxI15t6tGA38DHwt+JnJ1jpaAE4Sa8="]
   ttl     = 60
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -39,7 +39,7 @@ resource "aws_route53_record" "_amazonses_dmarc_TXT" {
   provider = aws.route53resourcechange
 
   name    = "_amazonses.${local.dmarc_domain_name}"
-  records = ["${aws_ses_domain_identity.dmarc_identity.verification_token}"]
+  records = [aws_ses_domain_identity.dmarc_identity.verification_token]
   ttl     = 60
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -58,9 +58,10 @@ resource "aws_route53_record" "wildcard_report_dmarc_TXT" {
 resource "aws_route53_record" "dkim_dmarc_CNAME" {
   provider = aws.route53resourcechange
 
-  count   = 3
-  name    = "${element(aws_ses_domain_dkim.dmarc_dkim.dkim_tokens, count.index)}._domainkey.${local.dmarc_domain_name}"
-  records = ["${element(aws_ses_domain_dkim.dmarc_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  for_each = toset(aws_ses_domain_dkim.dmarc_dkim.dkim_tokens)
+
+  name    = "${each.key}._domainkey.${local.dmarc_domain_name}"
+  records = ["${each.key}.dkim.amazonses.com"]
   ttl     = "600"
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_dmarc_app.tf
+++ b/route53_dmarc_app.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 # ------------------------------------------------------------------------------
-# Generation of the domain identity token in SES.
+# Generation of the domain identity token and DKIM keys in SES.
 # ------------------------------------------------------------------------------
 
 resource "aws_ses_domain_identity" "dmarc_identity" {

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -91,7 +91,7 @@ resource "aws_route53_record" "_amazonses_TXT" {
   provider = aws.route53resourcechange
 
   name    = "_amazonses.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["${aws_ses_domain_identity.cyhy_dhs_gov_identity.verification_token}"]
+  records = [aws_ses_domain_identity.cyhy_dhs_gov_identity.verification_token]
   ttl     = 60
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -100,9 +100,10 @@ resource "aws_route53_record" "_amazonses_TXT" {
 resource "aws_route53_record" "dkim_CNAME" {
   provider = aws.route53resourcechange
 
-  count   = 3
-  name    = "${element(aws_ses_domain_dkim.cyber_dhs_gov_dkim.dkim_tokens, count.index)}._domainkey.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["${element(aws_ses_domain_dkim.cyber_dhs_gov_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  for_each = toset(aws_ses_domain_dkim.cyber_dhs_gov_dkim.dkim_tokens)
+
+  name    = "${each.key}._domainkey.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["${each.key}.dkim.amazonses.com"]
   ttl     = "600"
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -18,6 +18,17 @@ resource "aws_route53_record" "root_CAA" {
 }
 
 # ------------------------------------------------------------------------------
+# Generation of the domain identity token in SES.
+# ------------------------------------------------------------------------------
+
+resource "aws_ses_domain_identity" "cyhy_dhs_gov_identity" {
+  provider = aws.route53resourcechange
+
+  domain = aws_route53_zone.cyber_dhs_gov.name
+}
+
+
+# ------------------------------------------------------------------------------
 # Resource records for email routing and security for the zone root.
 # ------------------------------------------------------------------------------
 
@@ -75,7 +86,7 @@ resource "aws_route53_record" "_amazonses_TXT" {
   provider = aws.route53resourcechange
 
   name    = "_amazonses.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["tOxXTap6jGLn6/VnBnget7lrXW+TxZTyTdOhm8LbM/Y="]
+  records = ["${aws_ses_domain_identity.cyhy_dhs_gov_identity.verification_token}"]
   ttl     = 60
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -25,7 +25,9 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
   statement {
     actions = [
       "ses:DeleteIdentity",
+      "ses:GetIdentityDkimAttributes",
       "ses:GetIdentityVerificationAttributes",
+      "ses:VerifyDomainDkim",
       "ses:VerifyDomainIdentity",
     ]
 

--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -21,6 +21,16 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
 
     resources = ["arn:aws:route53:::change/*"]
   }
+
+  statement {
+    actions = [
+      "ses:DeleteIdentity",
+      "ses:GetIdentityVerificationAttributes",
+      "ses:VerifyDomainIdentity",
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "route53resourcechange_policy" {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

The initial purpose of this branch was to add a missing DMARC record for the `dmarc.cyber.dhs.gov` subdomain.

It has expanded to include the generation of DKIM records for both the `cyber.dhs.gov` domain as well as the `dmarc.cyber.dhs.gov` subdomain.

It also includes the SES domain verification as this is a per-requisite to DKIM key generation.

**WARNING: This may affect our mail sending from non-COOL accounts.  Needs testing.**

<!--- Describe your changes in detail -->
Closes #3 
Closes #9 

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We starting getting messages from AWS saying the domain verification was failing due to a missing SES token TXT record.  

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed in the DNS account.  Triggered success emails from AWS.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
