### PR TITLE
Add a role to allow sending of emails via SES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 __pycache__
 .python-version
 .terraform
+*.tfvars
 terraform.tfstate
 terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ relationship with the users account.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | aws_region | The AWS region to communicate with. | `string` | `us-east-1` | no |
+| cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
 | route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |
 | route53resourcechange_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Route53ResourceChange-cyber.dhs.gov` | no |
+| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions send email via AWS SES. | `string` | `Allows sufficient permissions to send email via AWS SES.` | no |
+| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{"Application": "COOL - DNS - cyber.dhs.gov", "Team": "VM Fusion - Development", "Workspace": "production"}` | no |
 
 ## Outputs ##
@@ -27,6 +30,7 @@ relationship with the users account.
 |------|-------------|
 | cyber_dhs_gov_zone | The cyber.dhs.gov public hosted zone. |
 | route53resourcechange_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
+| sessendemail_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ relationship with the users account.
 | cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
 | route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |
 | route53resourcechange_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Route53ResourceChange-cyber.dhs.gov` | no |
-| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions send email via AWS SES. | `string` | `Allows sufficient permissions to send email via AWS SES.` | no |
+| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `Allows sufficient permissions to send email via AWS SES.` | no |
 | sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{"Application": "COOL - DNS - cyber.dhs.gov", "Team": "VM Fusion - Development", "Workspace": "production"}` | no |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "route53resourcechange_role" {
   value       = aws_iam_role.route53resourcechange_role
   description = "IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone."
 }
+
+output "sessendemail_role" {
+  value       = aws_iam_role.sessendemail_role
+  description = "IAM role that allows sufficient permissions to send email via AWS SES."
+}

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "sessendemail_doc" {
     ]
 
     resources = [
-      aws_ses_domain_identity.cyhy_dhs_gov_identity.arn
+      aws_ses_domain_identity.cyhy_dhs_gov_identity.arn,
     ]
   }
 }

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows the sending of email via AWS SES.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "sessendemail_doc" {
+  statement {
+    actions = [
+      "ses:Send*",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sessendemail_policy" {
+  provider = aws.dnsprovisionaccount
+
+  description = var.sessendemail_role_description
+  name        = var.sessendemail_role_name
+  policy      = data.aws_iam_policy_document.sessendemail_doc.json
+}

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "sessendemail_doc" {
     ]
 
     resources = [
-      "*"
+      aws_ses_domain_identity.cyhy_dhs_gov_identity.arn
     ]
   }
 }

--- a/sessendemail_role.tf
+++ b/sessendemail_role.tf
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows the sending of email via AWS SES
+# ------------------------------------------------------------------------------
+
+# An IAM policy document that allows the users account and the CyHy
+# account to assume the role.
+data "aws_iam_policy_document" "sessendemail_assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.users_account_id,
+        var.cyhy_account_id,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "sessendemail_role" {
+  provider = aws.dnsprovisionaccount
+
+  assume_role_policy = data.aws_iam_policy_document.sessendemail_assume_role_doc.json
+  description        = var.sessendemail_role_description
+  name               = var.sessendemail_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sessendemail_policy_attachment" {
+  provider = aws.dnsprovisionaccount
+
+  policy_arn = aws_iam_policy.sessendemail_policy.arn
+  role       = aws_iam_role.sessendemail_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "cyhy_account_id" {
+  type        = string
+  description = "The ID of the CyHy account."
+}
+
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
@@ -14,11 +19,6 @@ variable "aws_region" {
   type        = string
   description = "The AWS region to communicate with."
   default     = "us-east-1"
-}
-
-variable "cyhy_account_id" {
-  type        = string
-  description = "The ID of the CyHy account."
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,14 @@
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region to communicate with."
   default     = "us-east-1"
+}
+
+variable "cyhy_account_id" {
+  type        = string
+  description = "The ID of the CyHy account."
 }
 
 variable "tags" {
@@ -26,11 +32,25 @@ variable "tags" {
 }
 
 variable "route53resourcechange_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone."
   default     = "Allows sufficient permissions to modify resource records in the DNS zone."
 }
 
 variable "route53resourcechange_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone."
   default     = "Route53ResourceChange-cyber.dhs.gov"
+}
+
+variable "sessendemail_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
+  default     = "Allows sufficient permissions to send email via AWS SES."
+}
+
+variable "sessendemail_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
+  default     = "SesSendEmail-cyber.dhs.gov"
 }


### PR DESCRIPTION
## 🗣 Description

This pull request adds a role that allows sending of emails via SES.

## 💭 Motivation and Context

Since only a single account can be verified for a given email domain, `cyber.dhs.gov` emails can no longer be sent out via SES in the old CyHy account.  They must instead be sent via SES in the COOL DNS account, where that domain is now verified.  In order for this to happen, there must be a role in the COOL DNS account that can be assumed.

This pull request is linked to cisagov/cyhy-mailer#75, and is the Laurel to cisagov/cyhy_amis#255's Hardy.

## 🧪 Testing

I successfully sent out the CyHy, CybEx, and BOD 18-01 reports with these changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
