### PR TITLE
Enable SES notifications

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -19,6 +19,12 @@ locals {
   # Extract the user name of the current caller for use as assume role session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
 
+  # Find the DNS account by name
+  dns_account_id = [
+    for x in data.aws_organizations_organization.cool.accounts :
+    x.id if x.name == "DNS"
+  ][0]
+
   # Find the new Users account by name and email.
   users_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -33,6 +33,12 @@ resource "aws_ses_domain_dkim" "cyber_dhs_gov_dkim" {
   domain = aws_ses_domain_identity.cyhy_dhs_gov_identity.domain
 }
 
+# It would be nice to add aws_sns_topic_subscription resources for the
+# bounce and complaint email notifications below, but Terraform cannot
+# support that because such subscriptions must be approved out of
+# band.  See, for example, here:
+# https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html#email
+
 # cyber.dhs.gov bounce SNS
 resource "aws_sns_topic" "cyber_dhs_gov_bounce" {
   provider = aws.route53resourcechange

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -90,7 +90,7 @@ resource "aws_sqs_queue" "cyber_dhs_gov_delivery" {
   provider = aws.route53resourcechange
 
   # This is one fortnight (14 days)
-  message_retention_seconds = 1209600
+  message_retention_seconds = 60 * 60 * 24 * 14
   name                      = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}delivery"
   tags                      = var.tags
 }

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -33,6 +33,11 @@ resource "aws_ses_domain_dkim" "cyber_dhs_gov_dkim" {
   domain = aws_ses_domain_identity.cyhy_dhs_gov_identity.domain
 }
 
+# ------------------------------------------------------------------------------
+# Create the infrastructure for SES bounce, complaint, and delivery
+# notifications.
+# ------------------------------------------------------------------------------
+
 # It would be nice to add aws_sns_topic_subscription resources for the
 # bounce and complaint email notifications below, but Terraform cannot
 # support that because such subscriptions must be approved out of

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -89,6 +89,7 @@ resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_delivery" {
 resource "aws_sqs_queue" "cyber_dhs_gov_delivery" {
   provider = aws.route53resourcechange
 
+  # This is one fortnight (14 days)
   message_retention_seconds = 1209600
   name                      = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}delivery"
   tags                      = var.tags

--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -26,12 +26,37 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
     actions = [
       "ses:DeleteIdentity",
       "ses:GetIdentityDkimAttributes",
+      "ses:GetIdentityNotificationAttributes",
       "ses:GetIdentityVerificationAttributes",
+      "ses:SetIdentityHeadersInNotificationsEnabled",
+      "ses:SetIdentityNotificationTopic",
       "ses:VerifyDomainDkim",
       "ses:VerifyDomainIdentity",
     ]
 
     resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "sns:*",
+    ]
+
+    resources = [
+      "arn:aws:sns:${var.aws_region}:${local.dns_account_id}:cyber_dhs_gov_bounce",
+      "arn:aws:sns:${var.aws_region}:${local.dns_account_id}:cyber_dhs_gov_complaint",
+      "arn:aws:sns:${var.aws_region}:${local.dns_account_id}:cyber_dhs_gov_delivery",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:*",
+    ]
+
+    resources = [
+      "arn:aws:sqs:${var.aws_region}:${local.dns_account_id}:cyber_dhs_gov_delivery",
+    ]
   }
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds several AWS resources to enable SES notifications for bounces, complaints, and successful deliveries.

Note that [it is not possible](https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html#email) for Terraform to create an email subscription to an SNS topic.  Therefore I have added those subscriptions manually in the AWS console.

Also note that I am not against pulling the SES domain jazz out into its own repository.  It does complicate the code in this repository, which otherwise involves only Route53.  What do you think, @felddy, @dav3r, and @mcdonnnj?

## 💭 Motivation and Context

The devs and the CyHy folks should receive notifications when emails sent via `cyber.dhs.gov` bounce, or when complaints are received about the domain.  It is also convenient to have an SQS queue with successful delivery data, so when customers complain that they didn't receive their emails we can check and assure them that they reached the customer's server.

## 🧪 Testing

These changes are already deployed to COOL production, and I am waiting to receive our first bounce notification.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
