### PR TITLE
Add a MAIL FROM resource

### DIFF
--- a/route53_static.tf
+++ b/route53_static.tf
@@ -187,7 +187,7 @@ resource "aws_route53_record" "dkim_CNAME" {
 # Set up mail.${aws_route53_zone.cyber_dhs_gov.name} as SES MAIL FROM
 # resource.
 # ------------------------------------------------------------------------------
-resource "aws_ses_domain_mail_from" "example" {
+resource "aws_ses_domain_mail_from" "cyber_dhs_gov" {
   provider = aws.route53resourcechange
 
   domain           = aws_ses_domain_identity.cyhy_dhs_gov_identity.domain

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -182,3 +182,14 @@ resource "aws_route53_record" "dkim_CNAME" {
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
+
+# ------------------------------------------------------------------------------
+# Set up mail.${aws_route53_zone.cyber_dhs_gov.name} as SES MAIL FROM
+# resource.
+# ------------------------------------------------------------------------------
+resource "aws_ses_domain_mail_from" "example" {
+  provider = aws.route53resourcechange
+
+  domain           = aws_ses_domain_identity.cyhy_dhs_gov_identity.domain
+  mail_from_domain = "mail.${aws_ses_domain_identity.cyhy_dhs_gov_identity.domain}"
+}

--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -26,9 +26,11 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
     actions = [
       "ses:DeleteIdentity",
       "ses:GetIdentityDkimAttributes",
+      "ses:GetIdentityMailFromDomainAttributes",
       "ses:GetIdentityNotificationAttributes",
       "ses:GetIdentityVerificationAttributes",
       "ses:SetIdentityHeadersInNotificationsEnabled",
+      "ses:SetIdentityMailFromDomain",
       "ses:SetIdentityNotificationTopic",
       "ses:VerifyDomainDkim",
       "ses:VerifyDomainIdentity",


### PR DESCRIPTION
## 🗣 Description

This pull request adds a `mail.cyber.dhs.gov` MAIL FROM resource to our SES configuration.  We had such a resource in the old CyHy account, but it didn't make the initial move to the COOL.

## 💭 Motivation and Context

At least one stakeholder has reported that their reports are being placed into quarantine.  Their email is unclear, but this may because of a DMARC alignment failure.  This resource should help with that.

## 🧪 Testing

These changes have already been applied to production.  We will see next week if the stakeholder's reports end up in quarantine again.  Either way, this addition is a good thing to have.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
