### PR TITLE
Allow INL accounts to send email via cyber.dhs.gov

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @felddy @jsf9k

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-tf-module.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   CURL_CACHE_DIR: ~/.cache/curl
@@ -18,47 +19,49 @@ jobs:
     steps:
       - uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.13.8'
+          go-version: '1.14.2'
       - name: Store installed Python version
         run: |
           echo "::set-env name=PY_VERSION::"\
           "$(python -c "import platform;print(platform.python_version())")"
-      - name: Cache pip test requirements
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
-            ${{ hashFiles('**/requirements-test.txt') }}"
-          restore-keys: |
-            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
-            ${{ runner.os }}-pip-test-
-            ${{ runner.os }}-pip-
-      - name: Cache pre-commit hooks
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
-            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
-      - name: Cache curl downloads
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.CURL_CACHE_DIR }}
-          key: "${{ runner.os }}-curl-\
-            terraform-${{ env.TERRAFORM_VERSION }}"
+      - name: Store installed Go version
+        run: |
+          echo "::set-env name=GO_VERSION::"\
+          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')"
       - name: Lookup go cache directory
         id: go-cache
         run: |
           echo "::set-output name=dir::$(go env GOCACHE)"
-      - name: Cache go
-        uses: actions/cache@v1
+      - name: Cache linting environments
+        uses: actions/cache@v2
         with:
-          path: ${{ steps.go-cache.outputs.dir }}
-          key: "${{ runner.os }}-go"
+          # Note that the .terraform directory IS NOT included in the
+          # cache because we use the -upgrade=true option when we run
+          # terraform below.  That option pulls down the latest
+          # modules and providers no matter what, so there is no point
+          # in caching the .terraform directory.
+          path: |
+            ${{ env.PIP_CACHE_DIR }}
+            ${{ env.PRE_COMMIT_CACHE_DIR }}
+            ${{ env.CURL_CACHE_DIR }}
+            ${{ steps.go-cache.outputs.dir }}
+          key: "lint-${{ runner.os }}-\
+            py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
+            tf${{ env.TERRAFORM_VERSION }}-\
+            ${{ hashFiles('**/requirements-test.txt') }}-\
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
+          restore-keys: |
+            lint-${{ runner.os }}-\
+            py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
+            tf${{ env.TERRAFORM_VERSION }}-
+            lint-${{ runner.os }}-
       - name: Install Terraform
         run: |
           mkdir -p ${{ env.CURL_CACHE_DIR }}
@@ -71,11 +74,20 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
-        run: go get github.com/segmentio/terraform-docs
+        run: GO111MODULE=on go get github.com/segmentio/terraform-docs
+      - name: Find and initialize Terraform directories
+        run: |
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'..."; \
+            terraform init -upgrade=true -input=false -backend=false "$path"; \
+            done
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Set up pre-commit hook environments
+        run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .mypy_cache
-__pycache__
 .python-version
 .terraform
-*.tfvars
+__pycache__
 terraform.tfstate
 terraform.tfstate.backup
+*.tfvars

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,6 @@ import_heading_firstparty=cisagov Libraries
 known_third_party=
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=
+
+# Run isort under the black profile to align with our other Python linting
+profile=black

--- a/.mdl_config.json
+++ b/.mdl_config.json
@@ -3,5 +3,8 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": {
+    "allow_different_nesting": true
+  },
   "default": true
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.0
+    rev: v2.7.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,34 +61,47 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.0.7
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a3
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.12.0
+    rev: v1.31.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.1
+    rev: v2.0.0
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.782
     hooks:
       - id: mypy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,22 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
+If you already have `pyenv` and `pyenv-virtualenv` configured you can
+take advantage of the `setup-env` tool in this repo to automate the
+entire environment configuration process.
+
+```console
+./setup-env
+```
+
+Otherwise, follow the steps below to manually configure your
+environment.
+
 #### Installing and using `pyenv` and `pyenv-virtualenv` ####
 
-On the Mac, installation is as simple as `brew install pyenv
-pyenv-virtualenv` and adding this to your profile:
+On the Mac, we recommend installing [brew](https://brew.sh/).  Then
+installation is as simple as `brew install pyenv pyenv-virtualenv` and
+adding this to your profile:
 
 ```bash
 eval "$(pyenv init -)"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-dns-cyber.dhs.gov/workflows/build/badge.svg)](https://github.com/cisagov/cool-dns-cyber.dhs.gov/actions)
 
-This repository contains a Terraform configuration that will provision the DNS zone
-`cyber.dhs.gov` within the COOL.  It creates an IAM role that allows sufficient
-permissions to modify resources records in this zone.  This role has a trust
-relationship with the users account.
+This repository contains a Terraform configuration that will provision
+the DNS zone `cyber.dhs.gov` within the COOL.  It creates an IAM role
+that allows sufficient permissions to modify resources records in this
+zone.  This role has a trust relationship with the users account.
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,27 @@ relationship with the users account.
 1. Run the command `terraform init`.
 1. Run the command `terraform apply`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| aws.dnsprovisionaccount | ~> 2.0 |
+| aws.organizationsreadonly | ~> 2.0 |
+| aws.route53resourcechange | ~> 2.0 |
+| terraform | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws_region | The AWS region to communicate with. | `string` | `us-east-1` | no |
 | cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
 | route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ relationship with the users account.
 
 ## Notes ##
 
-Running `pre-commit` requires running `terraform init` in every directory that
-contains Terraform code. In this repository, these are the main directory and
-every directory under `examples/`.
+Running `pre-commit` requires running `terraform init` in every
+directory that contains Terraform code. In this repository, this is
+just the main directory.
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ relationship with the users account.
 | route53resourcechange_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
 | sessendemail_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 
+## Notes ##
+
+Running `pre-commit` requires running `terraform init` in every directory that
+contains Terraform code. In this repository, these are the main directory and
+every directory under `examples/`.
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/locals.tf
+++ b/locals.tf
@@ -25,6 +25,12 @@ locals {
     x.id if x.name == "DNS"
   ][0]
 
+  # Find the INL accounts by name
+  inl_account_ids = [
+    for x in data.aws_organizations_organization.cool.accounts :
+    x.id if length(regexall("^inl\\d+ \\((?:Staging|Production)\\)$", x.name)) > 0
+  ]
+
   # Find the new Users account by name and email.
   users_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
-# This is the "default" provider that is used assume the roles in the other providers.
-# It uses the credentials of the caller.   It is also used to assume the roles required
-# to access remote state in the Terraform backend.
-
+# This is the "default" provider that is used assume the roles in the
+# other providers.  It uses the credentials of the caller.  It is also
+# used to assume the roles required to access remote state in the
+# Terraform backend.
 provider "aws" {
   region = var.aws_region
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+--requirement requirements.txt
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/sessendemail_role.tf
+++ b/sessendemail_role.tf
@@ -12,10 +12,11 @@ data "aws_iam_policy_document" "sessendemail_assume_role_doc" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        local.users_account_id,
-        var.cyhy_account_id,
-      ]
+      # The users account needs to send an alert email when a new user
+      # is created.  The INL accounts need to send email for the PCA
+      # work they are doing.  The CyHy account needs to email the CyHy
+      # and BOD 18-01 reports and the CybEx scorecard.
+      identifiers = concat([local.users_account_id], local.inl_account_ids, [var.cyhy_account_id])
     }
   }
 }

--- a/setup-env
+++ b/setup-env
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+USAGE=$(cat << 'END_OF_LINE'
+Configure a developement environment for this repository.
+
+It does the following:
+  - Verifies pyenv and pyenv-virtualenv are installed.
+  - Creates a Python virtual environment.
+  - Configures the activation of the virtual enviroment for the repo directory.
+  - Installs the requirements needed for development.
+  - Installs git pre-commit hooks.
+  - Configures git upstream remote "lineage" repositories.
+
+Usage:
+  setup-env [options] [virt_env_name]
+  setup-env (-h | --help)
+
+Options:
+  -f --force          Delete virtual enviroment if it already exists.
+  -h --help           Show this message.
+  -i --install-hooks  Install hook environments for all environments in the
+                      pre-commit config file.
+
+END_OF_LINE
+)
+
+# Flag to force deletion and creation of virtual environment
+FORCE=0
+
+# Positional parameters
+PARAMS=""
+
+# Parse command line arguments
+while (( "$#" )); do
+  case "$1" in
+    -f|--force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    -i|--install-hooks)
+      INSTALL_HOOKS=1
+      shift
+      ;;
+    -*) # unsupported flags
+       echo "Error: Unsupported flag $1" >&2
+       exit 1
+       ;;
+    *) # preserve positional arguments
+       PARAMS="$PARAMS $1"
+       shift
+       ;;
+      esac
+done
+
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+# Check to see if pyenv is installed
+if [ -z "$(command -v pyenv)" ] || [ -z "$(command -v pyenv-virtualenv)" ]; then
+  echo "pyenv and pyenv-virtualenv are required."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    cat << 'END_OF_LINE'
+
+  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
+  profile:
+
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+
+END_OF_LINE
+
+  fi
+  cat << 'END_OF_LINE'
+  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
+  to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
+  the necessary tools. Before running this ensure that you have installed the
+  prerequisites for your platform according to the pyenv wiki page,
+  https://github.com/pyenv/pyenv/wiki/common-build-problems.
+
+  On WSL you should treat your platform as whatever Linux distribution you've
+  chosen to install.
+
+  Once you have installed "pyenv" you will need to add the following lines to
+  your ".bashrc":
+
+  export PATH="$PATH:$HOME/.pyenv/bin"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+END_OF_LINE
+  exit 1
+fi
+
+set +o nounset
+# Determine the virtual environment name
+if [ "$1" ]; then
+  # Use the user-provided environment name
+  env_name=$1
+else
+  # Set the environment name to the last part of the working directory.
+  env_name=${PWD##*/}
+fi
+set -o nounset
+
+# Remove any lingering local configuration.
+if [ $FORCE -ne 0 ]; then
+  rm -f .python-version
+  pyenv virtualenv-delete --force "${env_name}" || true
+elif [[ -f .python-version ]]; then
+  cat << 'END_OF_LINE'
+  An existing .python-version file was found.  Either remove this file yourself
+  or re-run with --force option to have it deleted along with the associated
+  virtual environment.
+
+  rm .python-version
+
+END_OF_LINE
+  exit 1
+fi
+
+# Create a new virtual environment for this project
+if ! pyenv virtualenv "${env_name}"; then
+  cat << END_OF_LINE
+  An existing virtual environment named $env_name was found.  Either delete this
+  environment yourself or re-run with --force option to have it deleted.
+
+  pyenv virtualenv-delete ${env_name}
+
+END_OF_LINE
+  exit 1
+fi
+
+# Set the local application-specific Python version(s) by writing the
+# version name to a file named `.python-version'.
+pyenv local "${env_name}"
+
+# Upgrade pip and friends
+python3 -m pip install --upgrade pip setuptools wheel
+
+# Find a requirements file (if possible) and install
+for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
+  if [[ -f $req_file ]]; then
+    pip install --requirement $req_file
+    break
+  fi
+done
+
+# Install git pre-commit hooks now or later.
+pre-commit install ${INSTALL_HOOKS:+"--install-hooks"}
+
+# Setup git remotes from lineage configuration
+# This could fail if the remotes are already setup, but that is ok.
+set +o errexit
+
+eval "$(python3 << 'END_OF_LINE'
+from pathlib import Path
+import yaml
+import sys
+
+LINEAGE_CONFIG = Path(".github/lineage.yml")
+
+if not LINEAGE_CONFIG.exists():
+    print("No lineage configuration found.", file=sys.stderr)
+    sys.exit(0)
+
+with LINEAGE_CONFIG.open("r") as f:
+    lineage = yaml.safe_load(stream=f)
+
+if lineage["version"] == "1":
+    for parent_name, v in lineage["lineage"].items():
+        remote_url = v["remote-url"]
+        print(f"git remote add {parent_name} {remote_url};")
+        print(f"git remote set-url --push {parent_name} no_push;")
+else:
+    print(f'Unsupported lineage version: {lineage["version"]}', file=sys.stderr)
+END_OF_LINE
+)"
+
+# Qapla
+echo "Success!"

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,11 @@
-
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
+
+  # If you use any other providers you should also pin them to the
+  # major version currently being used.  This practice will help us
+  # avoid unwelcome surprises.
+  required_providers {
+    aws = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Adds the account IDs of the INL accounts to the list of accounts allowed to send email via the `cyber.dhs.gov` domain.
* Adds a [Lineage](https://github.com/cisagov/action-lineage) configuration.
* Pulls in upstream changes from [cisagov/skeleton-tf-module](https://github.com/cisagov/skeleton-tf-module).

## 💭 Motivation and Context

The INL folks need to be able to send email via `cyber.dhs.gov` for their Continuous PCA effort.

## 🧪 Testing

All pre-commit hooks pass.  I have also successfully deployed this code to our production environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
