### PR TITLE
Change policy to also allow removal of emails from the suppression list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ zone.  This role has a trust relationship with the users account.
 | cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
 | route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |
 | route53resourcechange_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Route53ResourceChange-cyber.dhs.gov` | no |
-| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `Allows sufficient permissions to send email via AWS SES.` | no |
-| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
+| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. | `string` | `Allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list.` | no |
+| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{"Application": "COOL - DNS - cyber.dhs.gov", "Team": "VM Fusion - Development", "Workspace": "production"}` | no |
 
 ## Outputs ##
@@ -48,7 +48,7 @@ zone.  This role has a trust relationship with the users account.
 |------|-------------|
 | cyber_dhs_gov_zone | The cyber.dhs.gov public hosted zone. |
 | route53resourcechange_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
-| sessendemail_role | IAM role that allows sufficient permissions to send email via AWS SES. |
+| sessendemail_role | IAM role that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. |
 
 ## Notes ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "route53resourcechange_role" {
 
 output "sessendemail_role" {
   value       = aws_iam_role.sessendemail_role
-  description = "IAM role that allows sufficient permissions to send email via AWS SES."
+  description = "IAM role that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
 }

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "sessendemail_doc" {
+  # Allow sending of email
   statement {
     actions = [
       "ses:Send*",
@@ -10,6 +11,17 @@ data "aws_iam_policy_document" "sessendemail_doc" {
 
     resources = [
       aws_ses_domain_identity.cyhy_dhs_gov_identity.arn,
+    ]
+  }
+
+  # Allow deletion of email addresses from the suppression list
+  statement {
+    actions = [
+      "ses:DeleteSuppressedDestination",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,13 +41,13 @@ variable "route53resourcechange_role_name" {
 
 variable "sessendemail_role_description" {
   type        = string
-  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
-  default     = "Allows sufficient permissions to send email via AWS SES."
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
+  default     = "Allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
 }
 
 variable "sessendemail_role_name" {
   type        = string
-  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
   default     = "SesSendEmail-cyber.dhs.gov"
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds permissions to the `SesSendEmail-cyber.dhs.gov` role to allow removal email addresses from the email suppression list.

## 💭 Motivation and Context

This change allows one to remove addresses from the email suppression list via the AWS CLI:
```bash
AWS_PROFILE=cool-dns-sessendemail-cyber.dhs.gov AWS_SHARED_CREDENTIALS_FILE=~/.aws/production_credentials AWS_DEFAULT_REGION=us-east-1 aws sesv2 delete-suppressed-destination --email-address user@example.com
```

We have found that removing addresses this way is preferable to removing them via the web UI, since the web UI gives no information as to whether the address was originally on the suppression list of not.

## 🧪 Testing

I have deployed these changes to our COOL production environment and successfully removed an email from the email suppression list.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
