### PR TITLE
Add more permissions related to the SES suppression list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ zone.  This role has a trust relationship with the users account.
 | cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
 | route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |
 | route53resourcechange_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Route53ResourceChange-cyber.dhs.gov` | no |
-| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. | `string` | `Allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list.` | no |
-| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
+| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list. | `string` | `Allows sufficient permissions to send email via AWS SES and manipulate the suppression list.` | no |
+| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{"Application": "COOL - DNS - cyber.dhs.gov", "Team": "VM Fusion - Development", "Workspace": "production"}` | no |
 
 ## Outputs ##

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -18,6 +18,11 @@ data "aws_iam_policy_document" "sessendemail_doc" {
   statement {
     actions = [
       "ses:DeleteSuppressedDestination",
+      "ses:GetSuppressedDestination",
+      "ses:ListSuppressedDestinations",
+      "ses:PutAccountSuppressionAttributes",
+      "ses:PutConfigurationSetSuppressionOptions",
+      "ses:PutSuppressedDestination",
     ]
 
     resources = [

--- a/variables.tf
+++ b/variables.tf
@@ -41,13 +41,13 @@ variable "route53resourcechange_role_name" {
 
 variable "sessendemail_role_description" {
   type        = string
-  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
-  default     = "Allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
+  default     = "Allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
 }
 
 variable "sessendemail_role_name" {
   type        = string
-  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
   default     = "SesSendEmail-cyber.dhs.gov"
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds more permissions related to the to the SES suppression list to the `SesSendEmail-cyber.dhs.gov` role.

## 💭 Motivation and Context

@mcdonnnj pointed out that, although the AWS console is very opaque about the suppression list, the CLI can provide a fair amount of information.  This may be useful in some cases; for instance, I was able to use these new permissions to pull a list of _all_ email addresses currently on the suppression list.  I sent this information to @climber-girl so she can determine if any or all these addresses should be removed from the suppression list.

## 🧪 Testing

I have successfully deployed and used these new permissions in our COOL production environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
