### PR TITLE
Allow PCA accounts to assume SES email-sending role

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -31,6 +31,12 @@ locals {
     x.id if length(regexall("^inl\\d+ \\((?:Staging|Production)\\)$", x.name)) > 0
   ]
 
+  # Find the PCA accounts by name
+  pca_account_ids = [
+    for x in data.aws_organizations_organization.cool.accounts :
+    x.id if length(regexall("^PCA \\((?:Staging|Production)\\)$", x.name)) > 0
+  ]
+
   # Find the new Users account by name and email.
   users_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -48,7 +48,7 @@ resource "aws_ses_domain_dkim" "cyber_dhs_gov_dkim" {
 resource "aws_sns_topic" "cyber_dhs_gov_bounce" {
   provider = aws.route53resourcechange
 
-  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}bounce"
+  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}_bounce"
   tags = var.tags
 }
 resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_bounce" {
@@ -64,7 +64,7 @@ resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_bounce" {
 resource "aws_sns_topic" "cyber_dhs_gov_complaint" {
   provider = aws.route53resourcechange
 
-  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}complaint"
+  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}_complaint"
   tags = var.tags
 }
 resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_complaint" {
@@ -80,7 +80,7 @@ resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_complaint" {
 resource "aws_sns_topic" "cyber_dhs_gov_delivery" {
   provider = aws.route53resourcechange
 
-  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}delivery"
+  name = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}_delivery"
   tags = var.tags
 }
 resource "aws_ses_identity_notification_topic" "cyber_dhs_gov_delivery" {
@@ -96,7 +96,7 @@ resource "aws_sqs_queue" "cyber_dhs_gov_delivery" {
 
   # This is one fortnight (14 days)
   message_retention_seconds = 60 * 60 * 24 * 14
-  name                      = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}delivery"
+  name                      = "${replace(aws_route53_zone.cyber_dhs_gov.name, ".", "_")}_delivery"
   tags                      = var.tags
 }
 resource "aws_sns_topic_subscription" "cyber_dhs_gov_bounce" {

--- a/sessendemail_role.tf
+++ b/sessendemail_role.tf
@@ -13,10 +13,10 @@ data "aws_iam_policy_document" "sessendemail_assume_role_doc" {
     principals {
       type = "AWS"
       # The users account needs to send an alert email when a new user
-      # is created.  The INL accounts need to send email for the PCA
+      # is created.  The INL and PCA accounts need to send email for the PCA
       # work they are doing.  The CyHy account needs to email the CyHy
       # and BOD 18-01 reports and the CybEx scorecard.
-      identifiers = concat([local.users_account_id], local.inl_account_ids, [var.cyhy_account_id])
+      identifiers = concat([local.users_account_id], local.inl_account_ids, local.pca_account_ids, [var.cyhy_account_id])
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds the new PCA accounts to the list of those accounts allowed to assume the SES email-sending role.

It also includes a minor change related to resource names - see https://github.com/cisagov/cool-dns-cyber.dhs.gov/commit/325e782864abec50ae4f72b785f9f233b50bcce2 for details.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##
This change is necessary in order for Con-PCA to send email from the COOL.

This work is part of https://github.com/cisagov/cool-system/issues/82.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I applied these changes with Terraform and manually verified that the new PCA accounts were trusted by the SES email-sending role and that no other changes were made.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
