### PR TITLE
Add NS records for Con-PCA

### DIFF
--- a/remote_state.tf
+++ b/remote_state.tf
@@ -3,6 +3,21 @@
 # outputs of one or more Terraform configurations as input data for this configuration.
 # ------------------------------------------------------------------------------
 
+data "terraform_remote_state" "dns" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-accounts/dns.tfstate"
+  }
+
+  workspace = "production"
+}
+
 data "terraform_remote_state" "master" {
   backend = "s3"
 
@@ -18,7 +33,7 @@ data "terraform_remote_state" "master" {
   workspace = "production"
 }
 
-data "terraform_remote_state" "dns" {
+data "terraform_remote_state" "pca_production" {
   backend = "s3"
 
   config = {
@@ -27,8 +42,23 @@ data "terraform_remote_state" "dns" {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/dns.tfstate"
+    key            = "con-pca-cicd/terraform.tfstate"
   }
 
   workspace = "production"
+}
+
+data "terraform_remote_state" "pca_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "con-pca-cicd/terraform.tfstate"
+  }
+
+  workspace = "staging"
 }

--- a/route53_pca.tf
+++ b/route53_pca.tf
@@ -10,7 +10,7 @@
 resource "aws_route53_record" "pca_production_NS" {
   provider = aws.route53resourcechange
 
-  name    = "con-pca.cool.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = data.terraform_remote_state.pca_production.outputs.hosted_zone_name
   ttl     = 86400
   type    = "NS"
   records = data.terraform_remote_state.pca_production.outputs.hosted_zone_name_servers
@@ -24,7 +24,7 @@ resource "aws_route53_record" "pca_production_NS" {
 resource "aws_route53_record" "pca_staging_NS" {
   provider = aws.route53resourcechange
 
-  name    = "con-pca.staging.cool.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = data.terraform_remote_state.pca_staging.outputs.hosted_zone_name
   ttl     = 30
   type    = "NS"
   records = data.terraform_remote_state.pca_staging.outputs.hosted_zone_name_servers

--- a/route53_pca.tf
+++ b/route53_pca.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "pca_production_NS" {
   provider = aws.route53resourcechange
 
   name    = "con-pca.cool.${aws_route53_zone.cyber_dhs_gov.name}"
-  ttl     = 30
+  ttl     = 86400
   type    = "NS"
   records = data.terraform_remote_state.pca_production.outputs.hosted_zone_name_servers
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id

--- a/route53_pca.tf
+++ b/route53_pca.tf
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------------------
+# Resource records that support the Continuous Phishing Campaign Assessment
+# (Con-PCA) application.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Production
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "pca_production_NS" {
+  provider = aws.route53resourcechange
+
+  name    = "con-pca.cool.${aws_route53_zone.cyber_dhs_gov.name}"
+  ttl     = 30
+  type    = "NS"
+  records = data.terraform_remote_state.pca_production.outputs.hosted_zone_name_servers
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+# ------------------------------------------------------------------------------
+# Staging
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "pca_staging_NS" {
+  provider = aws.route53resourcechange
+
+  name    = "con-pca.staging.cool.${aws_route53_zone.cyber_dhs_gov.name}"
+  ttl     = 30
+  type    = "NS"
+  records = data.terraform_remote_state.pca_staging.outputs.hosted_zone_name_servers
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds NS records that point to the name servers used by the Continuous Phishing Campaign Assessment (Con-PCA) application.

Thanks to @zenine07 for writing most of this Terraform code.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##
This allows Con-PCA to use their own name servers in the `cool.cyber.dhs.gov` domain.

This change is part of https://github.com/cisagov/cool-system/issues/82.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I verified that the NS records could be successfully created using the outputs from the PCA remote states.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
