### PR TITLE
Revert "Revert "Add NS records for Con-PCA""

### DIFF
--- a/remote_state.tf
+++ b/remote_state.tf
@@ -3,6 +3,21 @@
 # outputs of one or more Terraform configurations as input data for this configuration.
 # ------------------------------------------------------------------------------
 
+data "terraform_remote_state" "dns" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-accounts/dns.tfstate"
+  }
+
+  workspace = "production"
+}
+
 data "terraform_remote_state" "master" {
   backend = "s3"
 
@@ -18,7 +33,7 @@ data "terraform_remote_state" "master" {
   workspace = "production"
 }
 
-data "terraform_remote_state" "dns" {
+data "terraform_remote_state" "pca_production" {
   backend = "s3"
 
   config = {
@@ -27,8 +42,23 @@ data "terraform_remote_state" "dns" {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/dns.tfstate"
+    key            = "con-pca-cicd/terraform.tfstate"
   }
 
   workspace = "production"
+}
+
+data "terraform_remote_state" "pca_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "con-pca-cicd/terraform.tfstate"
+  }
+
+  workspace = "staging"
 }

--- a/route53_pca.tf
+++ b/route53_pca.tf
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------------------
+# Resource records that support the Continuous Phishing Campaign Assessment
+# (Con-PCA) application.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Production
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "pca_production_NS" {
+  provider = aws.route53resourcechange
+
+  name    = data.terraform_remote_state.pca_production.outputs.hosted_zone_name
+  ttl     = 86400
+  type    = "NS"
+  records = data.terraform_remote_state.pca_production.outputs.hosted_zone_name_servers
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+# ------------------------------------------------------------------------------
+# Staging
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "pca_staging_NS" {
+  provider = aws.route53resourcechange
+
+  name    = data.terraform_remote_state.pca_staging.outputs.hosted_zone_name
+  ttl     = 30
+  type    = "NS"
+  records = data.terraform_remote_state.pca_staging.outputs.hosted_zone_name_servers
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}


### PR DESCRIPTION
It's the rare "double revert"!  Further discussion with @zenine07 revealed that we actually do need some public DNS lookups for Con-PCA to handle inbound phishing clicks.

We will also have private DNS records for the Con-PCA administrative interface; those will only resolve for users on the COOL VPN.

Reverts cisagov/cool-dns-cyber.dhs.gov#35