### PR TITLE
Combine identically-named TXT records

### DIFF
--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -55,18 +55,11 @@ resource "aws_route53_record" "crossfeed_prod_docs_CNAME" {
 resource "aws_route53_record" "crossfeed_prod_TXT" {
   provider = aws.route53resourcechange
 
-  name    = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["amazonses:rkxSP4d4VmzpdVhKoONkBFT8XYa/vJrCHgs5rs25/L4="]
-  ttl     = 300
-  type    = "TXT"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "crossfeed_prod_SPF" {
-  provider = aws.route53resourcechange
-
-  name    = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["v=spf1 include:amazonses.com -all"]
+  name = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "amazonses:rkxSP4d4VmzpdVhKoONkBFT8XYa/vJrCHgs5rs25/L4=",
+    "v=spf1 include:amazonses.com -all",
+  ]
   ttl     = 300
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
@@ -219,18 +212,11 @@ resource "aws_route53_record" "crossfeed_staging_MX" {
 resource "aws_route53_record" "crossfeed_staging_TXT" {
   provider = aws.route53resourcechange
 
-  name    = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["amazonses:rv6QdeDe1r8/Hn5HkSmfO8FttR8A8/2pHXtsLEHQI34="]
-  ttl     = 300
-  type    = "TXT"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "crossfeed_staging_SPF" {
-  provider = aws.route53resourcechange
-
-  name    = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["v=spf1 include:amazonses.com -all"]
+  name = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "amazonses:rv6QdeDe1r8/Hn5HkSmfO8FttR8A8/2pHXtsLEHQI34=",
+    "v=spf1 include:amazonses.com -all",
+  ]
   ttl     = 300
   type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id


### PR DESCRIPTION
## 🗣 Description ##

This pull request combines TXT records with identical `name` attributes.

## 💭 Motivation and Context ##

This corrects a bug in #38 by @cablej that went undetected by me, our CI pipeline, and the human reviewers.  I only noticed it when I attempted to apply the changes via Terraform after merging the PR.  Terraform cannot create two TXT records with the same `name` attribute; they must be combined into a single record.

## 🧪 Testing ##

These changes have already been applied to COOL production.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
