### PR TITLE
Allow Domain Manager accounts to assume "SES SendEmail" role

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -25,6 +25,12 @@ locals {
     x.id if x.name == "DNS"
   ][0]
 
+  # Find the Domain Manager accounts by name
+  domainmanager_account_ids = [
+    for x in data.aws_organizations_organization.cool.accounts :
+    x.id if length(regexall("^Domain Manager \\((?:Staging|Production)\\)$", x.name)) > 0
+  ]
+
   # Find the INL accounts by name
   inl_account_ids = [
     for x in data.aws_organizations_organization.cool.accounts :

--- a/sessendemail_role.tf
+++ b/sessendemail_role.tf
@@ -12,11 +12,19 @@ data "aws_iam_policy_document" "sessendemail_assume_role_doc" {
 
     principals {
       type = "AWS"
-      # The users account needs to send an alert email when a new user
-      # is created.  The INL and PCA accounts need to send email for the PCA
-      # work they are doing.  The CyHy account needs to email the CyHy
-      # and BOD 18-01 reports and the CybEx scorecard.
-      identifiers = concat([local.users_account_id], local.inl_account_ids, local.pca_account_ids, [var.cyhy_account_id])
+      # Account usage needs:
+      # - CyHy: Email the CyHy and BOD 18-01 reports and the CybEx scorecard
+      # - Domain Manager: Send various notification emails to internal users
+      # - INL: Test sending phishing emails for Phishing Campaign Assessments
+      # - PCA: Send phishing emails for Phishing Campaign Assessments
+      # - Users: Send an alert email when a new user account is created
+      identifiers = concat(
+        [var.cyhy_account_id],
+        local.domainmanager_account_ids,
+        local.inl_account_ids,
+        local.pca_account_ids,
+        [local.users_account_id]
+      )
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the Domain Manager accounts to the list of those allowed to assume this project's [sessendemail_role](https://github.com/cisagov/cool-dns-cyber.dhs.gov/blob/develop/sessendemail_role.tf).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The Domain Manager application has a new requirement to send notification emails to its users for things like new account creation and when certain actions have completed.

Resolves #43.
  
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied these changes and verified (in the AWS console) that the Domain Manager account IDs were added to the "Trust relationships" tab for the `SesSendEmail-cyber.dhs.gov` role.

@zenine07 - please confirm that you are able to successfully assume that role and send email from the Domain Manager accounts.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
