### PR TITLE
Split the email-sending and suppression list management role into two roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,123 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 3.0 |
 | terraform | n/a |
 
+## Modules ##
+
+No modules.
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.route53resourcechange_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.sesmanagesuppressionlist_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.sessendemail_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.route53resourcechange_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.sesmanagesuppressionlist_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.sessendemail_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.route53resourcechange_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.sesmanagesuppressionlist_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.sessendemail_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_route53_record._amazonses_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record._amazonses_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record._dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_api_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_docs_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_ses_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_api_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_api_CNAME1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_api_CNAME2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_ses_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dkim_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dkim_dmarc_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dmarc_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.drop_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.fw01_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.fw02_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.mail_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.mail_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.pca_production_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.pca_staging_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.root_acm_rules_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.vip_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.vpn_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.wildcard_report_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.cyber_dhs_gov](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_ses_domain_dkim.cyber_dhs_gov_dkim](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim) | resource |
+| [aws_ses_domain_dkim.dmarc_dkim](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim) | resource |
+| [aws_ses_domain_identity.cyhy_dhs_gov_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity) | resource |
+| [aws_ses_domain_identity.dmarc_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity) | resource |
+| [aws_ses_domain_mail_from.cyber_dhs_gov](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_mail_from) | resource |
+| [aws_ses_identity_notification_topic.cyber_dhs_gov_bounce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
+| [aws_ses_identity_notification_topic.cyber_dhs_gov_complaint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
+| [aws_ses_identity_notification_topic.cyber_dhs_gov_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
+| [aws_sns_topic.cyber_dhs_gov_bounce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.cyber_dhs_gov_complaint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.cyber_dhs_gov_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.cyber_dhs_gov_bounce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_sqs_queue.cyber_dhs_gov_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.route53resourcechange_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sesmanagesuppressionlist_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sesmanagesuppressionlist_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sessendemail_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sessendemail_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [terraform_remote_state.dns](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.master](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.pca_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws_region | The AWS region to communicate with. | `string` | `us-east-1` | no |
-| cloudfront_zone_id | The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions. | `string` | `Z2FDTNDATAQYW2` | no |
-| cyhy_account_id | The ID of the CyHy account. | `string` | n/a | yes |
-| route53resourcechange_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Allows sufficient permissions to modify resource records in the DNS zone.` | no |
-| route53resourcechange_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `Route53ResourceChange-cyber.dhs.gov` | no |
-| sessendemail_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list. | `string` | `Allows sufficient permissions to send email via AWS SES and manipulate the suppression list.` | no |
-| sessendemail_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list. | `string` | `SesSendEmail-cyber.dhs.gov` | no |
+| aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
+| cloudfront\_zone\_id | The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions. | `string` | `"Z2FDTNDATAQYW2"` | no |
+| cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |
+| route53resourcechange\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `"Allows sufficient permissions to modify resource records in the DNS zone."` | no |
+| route53resourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `"Route53ResourceChange-cyber.dhs.gov"` | no |
+| sesmanagesuppressionlist\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to manage the suppression list. | `string` | `"Allows sufficient permissions to manage the suppression list."` | no |
+| sesmanagesuppressionlist\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to manage the suppression list. | `string` | `"SesManageSuppressionList-cyber.dhs.gov"` | no |
+| sessendemail\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"Allows sufficient permissions to send email via AWS SES."` | no |
+| sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created | `map(string)` | `{"Application": "COOL - DNS - cyber.dhs.gov", "Team": "VM Fusion - Development", "Workspace": "production"}` | no |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| cyber_dhs_gov_zone | The cyber.dhs.gov public hosted zone. |
-| route53resourcechange_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
-| sessendemail_role | IAM role that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list. |
+| cyber\_dhs\_gov\_zone | The cyber.dhs.gov public hosted zone. |
+| route53resourcechange\_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
+| sesmanagementsuppressionlist\_role | IAM role that allows sufficient permissions to remove email addresses from the suppression list. |
+| sessendemail\_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 
 ## Notes ##
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ No modules.
 |------|-------------|
 | cyber\_dhs\_gov\_zone | The cyber.dhs.gov public hosted zone. |
 | route53resourcechange\_role | IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone. |
-| sesmanagementsuppressionlist\_role | IAM role that allows sufficient permissions to remove email addresses from the suppression list. |
+| sesmanagesuppressionlist\_role | IAM role that allows sufficient permissions to remove email addresses from the suppression list. |
 | sessendemail\_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 
 ## Notes ##

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "route53resourcechange_role" {
   description = "IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone."
 }
 
-output "sesmanagementsuppressionlist_role" {
+output "sesmanagesuppressionlist_role" {
   value       = aws_iam_role.sesmanagesuppressionlist_role
   description = "IAM role that allows sufficient permissions to remove email addresses from the suppression list."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,12 @@ output "route53resourcechange_role" {
   description = "IAM role that allows sufficient permissions to modify resource records in the cyber.dhs.gov zone."
 }
 
+output "sesmanagementsuppressionlist_role" {
+  value       = aws_iam_role.sesmanagesuppressionlist_role
+  description = "IAM role that allows sufficient permissions to remove email addresses from the suppression list."
+}
+
 output "sessendemail_role" {
   value       = aws_iam_role.sessendemail_role
-  description = "IAM role that allows sufficient permissions to send email via AWS SES and remove email addresses from the suppression list."
+  description = "IAM role that allows sufficient permissions to send email via AWS SES."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "route53resourcechange_role" {
 
 output "sesmanagesuppressionlist_role" {
   value       = aws_iam_role.sesmanagesuppressionlist_role
-  description = "IAM role that allows sufficient permissions to remove email addresses from the suppression list."
+  description = "IAM role that allows sufficient permissions to manage the AWS SES suppression list."
 }
 
 output "sessendemail_role" {

--- a/sesmanagesuppressionlist_policy.tf
+++ b/sesmanagesuppressionlist_policy.tf
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows management of the AWS SES
+# suppression list.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "sesmanagesuppressionlist_doc" {
+  # Allow all suppression list manipulations
+  statement {
+    actions = [
+      "ses:DeleteSuppressedDestination",
+      "ses:GetSuppressedDestination",
+      "ses:ListSuppressedDestinations",
+      "ses:PutAccountSuppressionAttributes",
+      "ses:PutConfigurationSetSuppressionOptions",
+      "ses:PutSuppressedDestination",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sesmanagesuppressionlist_policy" {
+  provider = aws.dnsprovisionaccount
+
+  description = var.sesmanagesuppressionlist_role_description
+  name        = var.sesmanagesuppressionlist_role_name
+  policy      = data.aws_iam_policy_document.sesmanagesuppressionlist_doc.json
+}

--- a/sesmanagesuppressionlist_role.tf
+++ b/sesmanagesuppressionlist_role.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "sesmanagesuppressionlist_assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/sesmanagesuppressionlist_role.tf
+++ b/sesmanagesuppressionlist_role.tf
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows management of the AWS SES
+# suppression list.
+# ------------------------------------------------------------------------------
+
+# An IAM policy document that allows the users account to assume the
+# role.
+data "aws_iam_policy_document" "sesmanagesuppressionlist_assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.users_account_id,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "sesmanagesuppressionlist_role" {
+  provider = aws.dnsprovisionaccount
+
+  assume_role_policy = data.aws_iam_policy_document.sesmanagesuppressionlist_assume_role_doc.json
+  description        = var.sesmanagesuppressionlist_role_description
+  name               = var.sesmanagesuppressionlist_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sesmanagesuppressionlist_policy_attachment" {
+  provider = aws.dnsprovisionaccount
+
+  policy_arn = aws_iam_policy.sesmanagesuppressionlist_policy.arn
+  role       = aws_iam_role.sesmanagesuppressionlist_role.name
+}

--- a/sessendemail_policy.tf
+++ b/sessendemail_policy.tf
@@ -13,22 +13,6 @@ data "aws_iam_policy_document" "sessendemail_doc" {
       aws_ses_domain_identity.cyhy_dhs_gov_identity.arn,
     ]
   }
-
-  # Allow deletion of email addresses from the suppression list
-  statement {
-    actions = [
-      "ses:DeleteSuppressedDestination",
-      "ses:GetSuppressedDestination",
-      "ses:ListSuppressedDestinations",
-      "ses:PutAccountSuppressionAttributes",
-      "ses:PutConfigurationSetSuppressionOptions",
-      "ses:PutSuppressedDestination",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
 }
 
 resource "aws_iam_policy" "sessendemail_policy" {

--- a/sessendemail_role.tf
+++ b/sessendemail_role.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "sessendemail_assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/variables.tf
+++ b/variables.tf
@@ -39,15 +39,27 @@ variable "route53resourcechange_role_name" {
   default     = "Route53ResourceChange-cyber.dhs.gov"
 }
 
+variable "sesmanagesuppressionlist_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to manage the suppression list."
+  default     = "Allows sufficient permissions to manage the suppression list."
+}
+
+variable "sesmanagesuppressionlist_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to manage the suppression list."
+  default     = "SesManageSuppressionList-cyber.dhs.gov"
+}
+
 variable "sessendemail_role_description" {
   type        = string
-  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
-  default     = "Allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
+  default     = "Allows sufficient permissions to send email via AWS SES."
 }
 
 variable "sessendemail_role_name" {
   type        = string
-  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES and manipulate the suppression list."
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES."
   default     = "SesSendEmail-cyber.dhs.gov"
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request splits the email-sending and suppression list management role into two separate roles:
* An email-sending role
* A suppression list management role

## 💭 Motivation and context ##

This is convenient because we would like to give some folks permission to assume one function but not the other.  This pull request partially addresses #45.

Note that I also updated [these instructions](https://github.com/cisagov/cool-system/wiki/Removing-an-Email-Address-from-the-AWS-SES-Suppression-List).

## 🧪 Testing ##

All `pre-commit` hooks pass.  I've also gone ahead and applied these changes to our production COOL environment, and everything appears hunky-dory to me.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
