### PR TITLE
Delegate ceil.cyber.dhs.gov to the CEIL project

### DIFF
--- a/route53_ceil.tf
+++ b/route53_ceil.tf
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------------
+# Delegate ceil.cyber.dhs.gov to the public Route53 zone in the CEIL
+# project's DNS account.
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "ceil_NS" {
+  provider = aws.route53resourcechange
+
+  name = "ceil.cyber.dhs.gov"
+  ttl  = 86400
+  type = "NS"
+  records = [
+    "ns-1466.awsdns-55.org",
+    "ns-877.awsdns-45.net",
+    "ns-381.awsdns-47.com",
+    "ns-1661.awsdns-15.co.uk",
+  ]
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request delegates `ceil.cyber.dhs.gov` to the CEIL project.  This just involves creating an NS record pointing to the nameservers for the CEIL team's public Route53 zone that lives in their DNS account.

## 💭 Motivation and context ##

The CEIL project needs to be able to handle its own DNS.

## 🧪 Testing ##

I verified that with these changes I can now resolve `vpn.ceil.cyber.dhs.gov`.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
