### PR TITLE
Create CNAME record for SADR Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.sadr_stage_CNAME] (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vip_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vpn_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.wildcard_report_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.sadr_stage_CNAME] (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.sadr_stage_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vip_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vpn_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.wildcard_report_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/route53_sadr_app.tf
+++ b/route53_sadr_app.tf
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Resource records that support SADR
+
+# ------------------------------------------------------------------------------
+# Staging entries
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "sadr_stage_CNAME" {
+  provider = aws.route53resourcechange
+  name     = "staging.sadr.${aws_route53_zone.cyber_dhs_gov.name}"
+  records  = ["sadr-stage-1940583289.us-gov-west-1.elb.amazonaws.com"]
+  ttl      = 300
+  type     = "CNAME"
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The Software Attestation Data Repository (SADR) is a project managed by the VRC 
branch of VM, residing in the Landing Zone provided by ME.  The production domain 
will be hosted on cisa.gov while the staging and development domains will be hosted 
on cyber.dhs.gov.  This PR creates the CNAME record to point to the ALB in front of 
the application.

 ## 💭 Motivation and context ##

SADR is a new application, and has no DNS records configured yet.  This change is 
required to implement the associated CNAME record.

## 🧪 Testing ##

No pre-testing was performed.  After implementation a DNS resolver tool such as `dig` 
will return the results of the record.

![image](https://github.com/cisagov/cool-dns-cyber.dhs.gov/assets/32716325/201ea34c-9be7-4e6a-a9ac-86fe3593259b)

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code 
standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
