### PR TITLE
Update staging-cd route53 records

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements ##
+## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers ##
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules ##
+## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources ##
+## Resources
 
 | Name | Type |
 |------|------|
@@ -106,6 +106,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.root_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_acm_rules_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rsaa_dev_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_stage_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -143,7 +144,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs ##
+## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -151,10 +152,9 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
-| api\_gateway\_east\_1\_zone\_id | The Route 53 hosted zone ID for For us-east-1 endpoints. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
-| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for For edge-optimized endpoints. | `string` | `"Z2FDTNDATAQYW2"` | no |
+| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for edge-optimized endpoints. | `string` | `"Z2FDTNDATAQYW2"` | no |
+| api\_gateway\_zone\_id | The Route 53 hosted zone ID for us-east-1 endpoints. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
-| cloudfront\_zone\_id | The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions. | `string` | `"Z2FDTNDATAQYW2"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |
 | read\_terraform\_state\_role\_name | The name to assign the IAM role and policy that allows read-only access to the cool-dns-cyber.dhs.gov state in the S3 bucket where Terraform state is stored. | `string` | `"ReadCyberDhsGovTerraformState"` | no |
 | route53resourcechange\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify resource records in the DNS zone. | `string` | `"Allows sufficient permissions to modify resource records in the DNS zone."` | no |
@@ -165,7 +165,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs ##
+## Outputs
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+## Requirements ##
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers
+## Providers ##
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules
+## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources
+## Resources ##
 
 | Name | Type |
 |------|------|
@@ -144,7 +144,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs
+## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -164,7 +164,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs
+## Outputs ##
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
-| api\_gateway\_zone\_id | The Route 53 hosted zone ID for API Gateways. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
+| api\_gateway\_zone\_id | The Route 53 hosted zone ID for API gateways. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |
 | read\_terraform\_state\_role\_name | The name to assign the IAM role and policy that allows read-only access to the cool-dns-cyber.dhs.gov state in the S3 bucket where Terraform state is stored. | `string` | `"ReadCyberDhsGovTerraformState"` | no |

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
-| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for edge-optimized endpoints. | `string` | `"Z2FDTNDATAQYW2"` | no |
 | api\_gateway\_zone\_id | The Route 53 hosted zone ID for us-east-1 endpoints. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
-| api\_gateway\_east\_1\_zone\_id | The Route 53 hosted zone ID for us-east-1 endpoints. | `string` | `Z1UJRXOUMOOFQ8` | no |
-| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for edge-optimized endpoints. | `string` | `Z2FDTNDATAQYW2` | no |
+| api\_gateway\_east\_1\_zone\_id | The Route 53 hosted zone ID for For us-east-1 endpoints. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
+| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for For edge-optimized endpoints. | `string` | `"Z2FDTNDATAQYW2"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
 | cloudfront\_zone\_id | The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions. | `string` | `"Z2FDTNDATAQYW2"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
+| api\_gateway\_east\_1\_zone\_id | The Route 53 hosted zone ID for us-east-1 endpoints. | `string` | `Z1UJRXOUMOOFQ8` | no |
+| api\_gateway\_edge\_zone\_id | The Route 53 hosted zone ID for edge-optimized endpoints. | `string` | `Z2FDTNDATAQYW2` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
 | cloudfront\_zone\_id | The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions. | `string` | `"Z2FDTNDATAQYW2"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.root_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_acm_rules_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.rsaa_dev_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_stage_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -152,7 +151,7 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
-| api\_gateway\_zone\_id | The Route 53 hosted zone ID for us-east-1 endpoints. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
+| api\_gateway\_zone\_id | The Route 53 hosted zone ID for API Gateways. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |
 | cyhy\_account\_id | The ID of the CyHy account. | `string` | n/a | yes |
 | read\_terraform\_state\_role\_name | The name to assign the IAM role and policy that allows read-only access to the cool-dns-cyber.dhs.gov state in the S3 bucket where Terraform state is stored. | `string` | `"ReadCyberDhsGovTerraformState"` | no |

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -126,7 +126,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
     zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
@@ -139,7 +139,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
     zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
@@ -240,7 +240,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-y5130perp8.execute-api.us-east-1.amazonaws.com."
     zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
@@ -253,7 +253,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-y5130perp8.execute-api.us-east-1.amazonaws.com."
     zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -241,7 +241,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_A" {
 
   alias {
     name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
-    zone_id                = var.api_gateway_edge_zone_id
+    zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
   name    = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
@@ -254,7 +254,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_AAAA" {
 
   alias {
     name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
-    zone_id                = var.api_gateway_edge_zone_id
+    zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
   name    = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_A" {
 
   alias {
     name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
-    zone_id                = var.api_gateway_east_1_zone_id
+    zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
   name    = "staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
@@ -140,7 +140,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_AAAA" {
 
   alias {
     name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
-    zone_id                = var.api_gateway_east_1_zone_id
+    zone_id                = var.api_gateway_zone_id
     evaluate_target_health = false
   }
   name    = "staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -126,8 +126,8 @@ resource "aws_route53_record" "crossfeed_staging_cd_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "do8d5i2re25cf.cloudfront.net."
-    zone_id                = var.cloudfront_zone_id
+    name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
+    zone_id                = var.api_gateway_east_1_zone_id
     evaluate_target_health = false
   }
   name    = "staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
@@ -139,8 +139,8 @@ resource "aws_route53_record" "crossfeed_staging_cd_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "do8d5i2re25cf.cloudfront.net."
-    zone_id                = var.cloudfront_zone_id
+    name                   = "ljgrfkavt7.execute-api.us-east-1.amazonaws.com."
+    zone_id                = var.api_gateway_east_1_zone_id
     evaluate_target_health = false
   }
   name    = "staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
@@ -240,8 +240,8 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d2gj80j4xz3s5z.cloudfront.net."
-    zone_id                = var.cloudfront_zone_id
+    name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
+    zone_id                = var.api_gateway_edge_zone_id
     evaluate_target_health = false
   }
   name    = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
@@ -253,8 +253,8 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d2gj80j4xz3s5z.cloudfront.net."
-    zone_id                = var.cloudfront_zone_id
+    name                   = "mkrl99gnu9.execute-api.us-east-1.amazonaws.com."
+    zone_id                = var.api_gateway_edge_zone_id
     evaluate_target_health = false
   }
   name    = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -47,13 +47,13 @@ variable "aws_region" {
 
 variable "api_gateway_east_1_zone_id" {
   type        = string
-  description = "The Route 53 hosted zone ID for For us-east-1 endpoints."
+  description = "The Route 53 hosted zone ID for us-east-1 endpoints."
   default     = "Z1UJRXOUMOOFQ8"
 }
 
 variable "api_gateway_edge_zone_id" {
   type        = string
-  description = "The Route 53 hosted zone ID for For edge-optimized endpoints."
+  description = "The Route 53 hosted zone ID for edge-optimized endpoints."
   default     = "Z2FDTNDATAQYW2"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,12 +39,6 @@ variable "additional_ses_sendemail_account_ids" {
   default     = []
 }
 
-variable "api_gateway_edge_zone_id" {
-  type        = string
-  description = "The Route 53 hosted zone ID for edge-optimized endpoints."
-  default     = "Z2FDTNDATAQYW2"
-}
-
 variable "api_gateway_zone_id" {
   type        = string
   description = "The Route 53 hosted zone ID for us-east-1 endpoints."

--- a/variables.tf
+++ b/variables.tf
@@ -45,9 +45,15 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "cloudfront_zone_id" {
+variable "api_gateway_east_1_zone_id" {
   type        = string
-  description = "The ID of the Cloudfront hosted zone. This is set by AWS and is a constant across all Cloudfront distributions."
+  description = "The Route 53 hosted zone ID for For us-east-1 endpoints."
+  default     = "Z1UJRXOUMOOFQ8"
+}
+
+variable "api_gateway_edge_zone_id" {
+  type        = string
+  description = "The Route 53 hosted zone ID for For edge-optimized endpoints."
   default     = "Z2FDTNDATAQYW2"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,16 +39,16 @@ variable "additional_ses_sendemail_account_ids" {
   default     = []
 }
 
-variable "api_gateway_east_1_zone_id" {
-  type        = string
-  description = "The Route 53 hosted zone ID for us-east-1 endpoints."
-  default     = "Z1UJRXOUMOOFQ8"
-}
-
 variable "api_gateway_edge_zone_id" {
   type        = string
   description = "The Route 53 hosted zone ID for edge-optimized endpoints."
   default     = "Z2FDTNDATAQYW2"
+}
+
+variable "api_gateway_zone_id" {
+  type        = string
+  description = "The Route 53 hosted zone ID for us-east-1 endpoints."
+  default     = "Z1UJRXOUMOOFQ8"
 }
 
 variable "aws_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "additional_ses_sendemail_account_ids" {
 
 variable "api_gateway_zone_id" {
   type        = string
-  description = "The Route 53 hosted zone ID for API Gateways."
+  description = "The Route 53 hosted zone ID for API gateways."
   default     = "Z1UJRXOUMOOFQ8"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "additional_ses_sendemail_account_ids" {
 
 variable "api_gateway_zone_id" {
   type        = string
-  description = "The Route 53 hosted zone ID for us-east-1 endpoints."
+  description = "The Route 53 hosted zone ID for API Gateways."
   default     = "Z1UJRXOUMOOFQ8"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,12 +39,6 @@ variable "additional_ses_sendemail_account_ids" {
   default     = []
 }
 
-variable "aws_region" {
-  type        = string
-  description = "The AWS region to communicate with."
-  default     = "us-east-1"
-}
-
 variable "api_gateway_east_1_zone_id" {
   type        = string
   description = "The Route 53 hosted zone ID for us-east-1 endpoints."
@@ -55,6 +49,12 @@ variable "api_gateway_edge_zone_id" {
   type        = string
   description = "The Route 53 hosted zone ID for edge-optimized endpoints."
   default     = "Z2FDTNDATAQYW2"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "The AWS region to communicate with."
+  default     = "us-east-1"
 }
 
 variable "read_terraform_state_role_name" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Crossfeed's staging-cd infrastructure is no longer using Cloudfront, and has been replaced with API gateways. Therefore, the Route 53 record need to be updated to point at the APIs. 

## 💭 Motivation and context ##

Crossfeed's staging-cd infrastructure needs to match what we have in AWS GovCloud (doesn't support CloudFront).


## 🧪 Testing ##

- [x] Apply and test changes before merge

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.