### PR TITLE
Create TXT entry to generate ACME certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.ceil_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_api_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -47,9 +47,9 @@ resource "aws_route53_record" "crossfeed_prod_docs_CNAME" {
 resource "aws_route53_record" "crossfeed_prod_acme_TXT" {
   provider = aws.route53resourcechange
 
-  name = "_acme-challenge.prod.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  name = "_acme-challenge.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "AjujZpKd_IdUxJKOiczsDCCsUoUicAkTeVL52cXiVWc",
+    "ct0l3YNdaIble-FQ0CgaGrurEcZAVPn6OrphYnXmcRM",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -99,9 +99,9 @@ resource "aws_route53_record" "crossfeed_prod_api_acm_CNAME" {
 resource "aws_route53_record" "crossfeed_prod_api_acme_TXT" {
   provider = aws.route53resourcechange
 
-  name = "_acme-challenge.api.prod.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  name = "_acme-challenge.api.crossfeed.cyber.dhs.gov.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "VkfmPIgHqPRlnVz9wgXVCaaHBj63jqOm3ySsVpanFMQ",
+    "W0TCCWlQGWMiEncVtPUCihlNj0oj-6BcEPzOSwAjbY8",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -44,6 +44,18 @@ resource "aws_route53_record" "crossfeed_prod_docs_CNAME" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "crossfeed_prod_acme_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.prod.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "AjujZpKd_IdUxJKOiczsDCCsUoUicAkTeVL52cXiVWc",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 # ------------------------------------------------------------------------------
 # Prod API entries
 # ------------------------------------------------------------------------------
@@ -81,6 +93,18 @@ resource "aws_route53_record" "crossfeed_prod_api_acm_CNAME" {
   records = ["_829d98e4bbf4eeaae36108a98a720ce2.jfrzftwwjs.acm-validations.aws."]
   ttl     = 300
   type    = "CNAME"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "crossfeed_prod_api_acme_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.api.prod.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "Ex05wBdGQeoEu8kuI2zmTwz4tQx-7ShKYBnL-IbNy4A",
+  ]
+  ttl     = 3000
+  type    = "TXT"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -101,7 +101,7 @@ resource "aws_route53_record" "crossfeed_prod_api_acme_TXT" {
 
   name = "_acme-challenge.api.prod.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "Ex05wBdGQeoEu8kuI2zmTwz4tQx-7ShKYBnL-IbNy4A",
+    "VkfmPIgHqPRlnVz9wgXVCaaHBj63jqOm3ySsVpanFMQ",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -99,7 +99,7 @@ resource "aws_route53_record" "crossfeed_prod_api_acm_CNAME" {
 resource "aws_route53_record" "crossfeed_prod_api_acme_TXT" {
   provider = aws.route53resourcechange
 
-  name = "_acme-challenge.api.crossfeed.cyber.dhs.gov.${aws_route53_zone.cyber_dhs_gov.name}"
+  name = "_acme-challenge.api.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
     "W0TCCWlQGWMiEncVtPUCihlNj0oj-6BcEPzOSwAjbY8",
   ]


### PR DESCRIPTION
## 🗣 Description ##

We need to update the TXT record for the DNS to create a certificate for Let'sEncrypt. terraform-docs has been run.

Add/Update the  api.cyber.dhs.gov TXT, also had to add the TXT record for crossfeed.cyber.dhs.gov 

## 💭 Motivation and context ##

There are no existing ACME certs and these certs will be put in place of current certs

## 🧪 Testing ##

Ran terraform-docs to see if any changes were made to the docs

## ✅ Pre-approval checklist ##

 - [x] This PR has an informative and human-readable title.
 - [x] Changes are limited to a single goal - eschew scope creep!
 - [x] All relevant type-of-change labels have been added.
 - [x] I have read the [CONTRIBUTING](https://github.com/cisagov/cool-dns-cyber.dhs.gov/blob/develop/CONTRIBUTING.md) document.
 - [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
 - [x] All new and existing tests pass.