### PR TITLE
Add DNS TXT record for ReadySetCyber

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_docs_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -103,6 +102,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.mail_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_production_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_staging_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_docs_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.crossfeed_readysetcyber.acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.crossfeed_readysetcyber.acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_docs_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_readysetcyber.acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_readysetcyber.acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -59,9 +59,9 @@ resource "aws_route53_record" "crossfeed_prod_acme_TXT" {
 resource "aws_route53_record" "ready_set_cyber_prod_acme_TXT" {
   provider = aws.route53resourcechange
 
-  name = "_acme-challenge.readysetcyber.cyber.dhs.gov.${aws_route53_zone.cyber_dhs_gov.name}"
+  name = "_acme-challenge.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "Kut2kbnCwqWzbSOZ5hGWAICO2gUG4Y1zKD9xsbsFZDU",
+    "lBVDy-eRJNPE2kLsri9_ED6_Ds5Dthq4QtUMIsJmZ3g",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -56,6 +56,18 @@ resource "aws_route53_record" "crossfeed_prod_acme_TXT" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "ready_set_cyber_prod_acme_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.readysetcyber.cyber.dhs.gov.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "ggiSDj6en3OqaS4Jw-6kzljOE5BN_92QlQkjGqlCaMU",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 # ------------------------------------------------------------------------------
 # Prod API entries
 # ------------------------------------------------------------------------------

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "ready_set_cyber_prod_acme_TXT" {
 
   name = "_acme-challenge.readysetcyber.cyber.dhs.gov.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "ggiSDj6en3OqaS4Jw-6kzljOE5BN_92QlQkjGqlCaMU",
+    "Kut2kbnCwqWzbSOZ5hGWAICO2gUG4Y1zKD9xsbsFZDU",
   ]
   ttl     = 3000
   type    = "TXT"


### PR DESCRIPTION
Add DNS TXT record for ReadySetCyber

## 🗣 Description ##
We need to update the TXT record for the DNS to create a certificate for Let'sEncrypt. terraform-docs has been run.

Add/Update the ReadySetCyber.cyber.dhs.gov TXT

## 💭 Motivation and context ##
There are no existing ACME certs

## 🧪 Testing ##
Ran terraform-docs to see if any changes were made to the docs

## ✅ Pre-approval checklist ##
 - [x] This PR has an informative and human-readable title.
 - [x] Changes are limited to a single goal - eschew scope creep!
 - [x] All relevant type-of-change labels have been added.
 - [x] I have read the [CONTRIBUTING](https://github.com/cisagov/cool-dns-cyber.dhs.gov/blob/develop/CONTRIBUTING.md) document.
 - [x]  These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
 - [x] All new and existing tests pass.