### PR TITLE
Add new route53 file with DNS changes for Readysetcyber and XFD

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+## Requirements ##
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers
+## Providers ##
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules
+## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources
+## Resources ##
 
 | Name | Type |
 |------|------|
@@ -166,7 +166,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs
+## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -186,7 +186,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs
+## Outputs ##
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,26 +1,12 @@
-# cool-dns-cyber.dhs.gov #
-
-[![GitHub Build Status](https://github.com/cisagov/cool-dns-cyber.dhs.gov/workflows/build/badge.svg)](https://github.com/cisagov/cool-dns-cyber.dhs.gov/actions)
-
-This repository contains a Terraform configuration that will provision
-the DNS zone `cyber.dhs.gov` within the COOL.  It creates an IAM role
-that allows sufficient permissions to modify resources records in this
-zone.  This role has a trust relationship with the users account.
-
-## Usage ##
-
-1. Run the command `terraform init`.
-1. Run the command `terraform apply`.
-
 <!-- BEGIN_TF_DOCS -->
-## Requirements ##
+## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers ##
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -31,13 +17,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules ##
+## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources ##
+## Resources
 
 | Name | Type |
 |------|------|
@@ -58,6 +44,11 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record._amazonses_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record._amazonses_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record._dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ceil_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -66,6 +57,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -89,6 +81,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_staging_cd_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -102,7 +95,10 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.mail_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_production_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_staging_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -150,7 +146,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs ##
+## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -170,7 +166,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs ##
+## Outputs
 
 | Name | Description |
 |------|-------------|
@@ -180,27 +176,3 @@ zone.  This role has a trust relationship with the users account.
 | sesmanagesuppressionlist\_role | IAM role that allows sufficient permissions to manage the AWS SES suppression list. |
 | sessendemail\_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 <!-- END_TF_DOCS -->
-
-## Notes ##
-
-Running `pre-commit` requires running `terraform init` in every
-directory that contains Terraform code. In this repository, this is
-just the main directory.
-
-## Contributing ##
-
-We welcome contributions!  Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
-details.
-
-## License ##
-
-This project is in the worldwide [public domain](LICENSE).
-
-This project is in the public domain within the United States, and
-copyright and related rights in the work worldwide are waived through
-the [CC0 1.0 Universal public domain
-dedication](https://creativecommons.org/publicdomain/zero/1.0/).
-
-All contributions to this project will be released under the CC0
-dedication. By submitting a pull request, you are agreeing to comply
-with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record._amazonses_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record._amazonses_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record._dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ceil_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -66,6 +71,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_prod_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acm_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_api_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -89,6 +95,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_staging_cd_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -102,7 +109,10 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.mail_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_production_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_staging_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
+# cool-dns-cyber.dhs.gov #
+
+[![GitHub Build Status](https://github.com/cisagov/cool-dns-cyber.dhs.gov/workflows/build/badge.svg)](https://github.com/cisagov/cool-dns-cyber.dhs.gov/actions)
+
+This repository contains a Terraform configuration that will provision
+the DNS zone `cyber.dhs.gov` within the COOL.  It creates an IAM role
+that allows sufficient permissions to modify resources records in this
+zone.  This role has a trust relationship with the users account.
+
+## Usage ##
+
+1. Run the command `terraform init`.
+1. Run the command `terraform apply`.
+
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+## Requirements ##
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers
+## Providers ##
 
 | Name | Version |
 |------|---------|
@@ -17,13 +31,13 @@
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules
+## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources
+## Resources ##
 
 | Name | Type |
 |------|------|
@@ -46,9 +60,12 @@
 | [aws_route53_record._dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.api_ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_staging_ready_set_cyber_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_staging_ready_set_cyber_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ceil_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -95,7 +112,8 @@
 | [aws_route53_record.mail_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_production_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.pca_staging_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.ready_set_cyber_prod_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -114,6 +132,8 @@
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.staging_ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.staging_ready_set_cyber_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vip_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vpn_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.wildcard_report_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -146,7 +166,7 @@
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs
+## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -166,7 +186,7 @@
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs
+## Outputs ##
 
 | Name | Description |
 |------|-------------|
@@ -176,3 +196,27 @@
 | sesmanagesuppressionlist\_role | IAM role that allows sufficient permissions to manage the AWS SES suppression list. |
 | sessendemail\_role | IAM role that allows sufficient permissions to send email via AWS SES. |
 <!-- END_TF_DOCS -->
+
+## Notes ##
+
+Running `pre-commit` requires running `terraform init` in every
+directory that contains Terraform code. In this repository, this is
+just the main directory.
+
+## Contributing ##
+
+We welcome contributions!  Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+details.
+
+## License ##
+
+This project is in the worldwide [public domain](LICENSE).
+
+This project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain
+dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -98,6 +98,24 @@ resource "aws_route53_record" "crossfeed_prod_api_AAAA" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "crossfeed_prod_digicert_CAA" {
+ provider = aws.route53resourcechange
+ zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+ name    = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+ type    = "CAA"
+ ttl     = 3600
+ records = ["0 issue \"digicert.com\""]
+}
+
+resource "aws_route53_record" "api_crossfeed_prod_digicert_CAA" {
+ provider = aws.route53resourcechange
+ zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+ name    = "api.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+ type    = "CAA"
+ ttl     = 3600
+ records = ["0 issue \"digicert.com\""]
+}
+
 resource "aws_route53_record" "crossfeed_prod_api_acm_CNAME" {
   provider = aws.route53resourcechange
 
@@ -210,6 +228,24 @@ resource "aws_route53_record" "crossfeed_staging_AAAA" {
   name    = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   type    = "AAAA"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "crossfeed_staging_digicert_CAA" {
+ provider = aws.route53resourcechange
+ zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+ name     = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+ type     = "CAA"
+ ttl      = 3600
+ records  = ["0 issue \"digicert.com\""]
+}
+
+resource "aws_route53_record" "api_crossfeed_staging_digicert_CAA" {
+ provider = aws.route53resourcechange
+ zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+ name    = "api.crossfeed.staging.${aws_route53_zone.cyber_dhs_gov.name}"
+ type    = "CAA"
+ ttl     = 3600
+ records = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "crossfeed_staging_CNAME" {

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -99,21 +99,21 @@ resource "aws_route53_record" "crossfeed_prod_api_AAAA" {
 }
 
 resource "aws_route53_record" "crossfeed_prod_digicert_CAA" {
- provider = aws.route53resourcechange
- zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
- name    = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
- type    = "CAA"
- ttl     = 3600
- records = ["0 issue \"digicert.com\""]
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "api_crossfeed_prod_digicert_CAA" {
- provider = aws.route53resourcechange
- zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
- name    = "api.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
- type    = "CAA"
- ttl     = 3600
- records = ["0 issue \"digicert.com\""]
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "api.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "crossfeed_prod_api_acm_CNAME" {
@@ -231,21 +231,21 @@ resource "aws_route53_record" "crossfeed_staging_AAAA" {
 }
 
 resource "aws_route53_record" "crossfeed_staging_digicert_CAA" {
- provider = aws.route53resourcechange
- zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
- name     = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
- type     = "CAA"
- ttl      = 3600
- records  = ["0 issue \"digicert.com\""]
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "staging.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "api_crossfeed_staging_digicert_CAA" {
- provider = aws.route53resourcechange
- zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
- name    = "api.crossfeed.staging.${aws_route53_zone.cyber_dhs_gov.name}"
- type    = "CAA"
- ttl     = 3600
- records = ["0 issue \"digicert.com\""]
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "api.crossfeed.staging.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "crossfeed_staging_CNAME" {

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -15,16 +15,36 @@ resource "aws_route53_record" "ready_set_cyber_prod_digicert_CAA" {
   name     = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
- records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }
 
-resource "aws_route53_record" "ready_set_cyber_prod_CNAME" {
+
+
+# The hosted_zone_id for the below records comes from https://docs.aws.amazon.com/general/latest/gr/elb.html
+# (ALBs in us-gov-west-1 region)
+resource "aws_route53_record" "ready_set_cyber_prod_A" {
   provider = aws.route53resourcechange
 
+  alias {
+    name                   = "crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
   name    = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."]
-  ttl     = 300
-  type    = "CNAME"
+  type    = "A"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "ready_set_cyber_prod_AAAA" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "AAAA"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
@@ -39,16 +59,32 @@ resource "aws_route53_record" "api_ready_set_cyber_prod_digicert_CAA" {
   name     = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }
 
-resource "aws_route53_record" "api_ready_set_cyber_prod_CNAME" {
+resource "aws_route53_record" "api_ready_set_cyber_prod_A" {
   provider = aws.route53resourcechange
 
+  alias {
+    name                   = "crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
   name    = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."]
-  ttl     = 300
-  type    = "CNAME"
+  type    = "A"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "api_ready_set_cyber_prod_AAAA" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "AAAA"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
@@ -63,7 +99,32 @@ resource "aws_route53_record" "ready_set_cyber_staging_digicert_CAA" {
   name     = "staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
+}
+resource "aws_route53_record" "staging_ready_set_cyber_staging_A" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-stage-1792947306.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "A"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "staging_ready_set_cyber_prod_AAAA" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-stage-1792947306.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "AAAA"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
 
@@ -76,5 +137,31 @@ resource "aws_route53_record" "api_ready_set_cyber_staging_digicert_CAA" {
   name     = "api.staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
+}
+
+resource "aws_route53_record" "api_staging_ready_set_cyber_staging_A" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-stage-1792947306.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "api.staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "A"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "api_staging_ready_set_cyber_staging_AAAA" {
+  provider = aws.route53resourcechange
+
+  alias {
+    name                   = "crossfeed-stage-1792947306.us-gov-west-1.elb.amazonaws.com."
+    zone_id                = "Z33AYJ8TM3BH4J"
+    evaluate_target_health = false
+  }
+  name    = "api.staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type    = "AAAA"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -15,7 +15,7 @@ resource "aws_route53_record" "ready_set_cyber_prod_digicert_CAA" {
   name     = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
- records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "ready_set_cyber_prod_CNAME" {
@@ -39,7 +39,7 @@ resource "aws_route53_record" "api_ready_set_cyber_prod_digicert_CAA" {
   name     = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }
 
 resource "aws_route53_record" "api_ready_set_cyber_prod_CNAME" {
@@ -63,7 +63,7 @@ resource "aws_route53_record" "ready_set_cyber_staging_digicert_CAA" {
   name     = "staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }
 
 
@@ -76,5 +76,5 @@ resource "aws_route53_record" "api_ready_set_cyber_staging_digicert_CAA" {
   name     = "api.staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
   type     = "CAA"
   ttl      = 3600
-  records = ["0 issue \"digicert.com\""]
+  records  = ["0 issue \"digicert.com\""]
 }

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -1,0 +1,80 @@
+# ------------------------------------------------------------------------------
+# Resource records that support ReadySetCyber site cloudfront endpoints and application.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Prod entries
+# ------------------------------------------------------------------------------
+
+# The hosted_zone_id for the below records comes from https://docs.aws.amazon.com/general/latest/gr/elb.html
+# (ALBs in us-gov-west-1 region)
+
+resource "aws_route53_record" "ready_set_cyber_prod_digicert_CAA" {
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+ records = ["0 issue \"digicert.com\""]
+}
+
+resource "aws_route53_record" "ready_set_cyber_prod_CNAME" {
+  provider = aws.route53resourcechange
+
+  name    = "readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."]
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+
+
+# ------------------------------------------------------------------------------
+# Prod API entries
+# ------------------------------------------------------------------------------
+resource "aws_route53_record" "api_ready_set_cyber_prod_digicert_CAA" {
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records = ["0 issue \"digicert.com\""]
+}
+
+resource "aws_route53_record" "api_ready_set_cyber_prod_CNAME" {
+  provider = aws.route53resourcechange
+
+  name    = "api.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["crossfeed-prod-1638162291.us-gov-west-1.elb.amazonaws.com."]
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+
+
+# ------------------------------------------------------------------------------
+# Staging entries
+# ------------------------------------------------------------------------------
+resource "aws_route53_record" "ready_set_cyber_staging_digicert_CAA" {
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records = ["0 issue \"digicert.com\""]
+}
+
+
+# ------------------------------------------------------------------------------
+# Staging API entries
+# ------------------------------------------------------------------------------
+resource "aws_route53_record" "api_ready_set_cyber_staging_digicert_CAA" {
+  provider = aws.route53resourcechange
+  zone_id  = aws_route53_zone.cyber_dhs_gov.zone_id
+  name     = "api.staging.readysetcyber.${aws_route53_zone.cyber_dhs_gov.name}"
+  type     = "CAA"
+  ttl      = 3600
+  records = ["0 issue \"digicert.com\""]
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add CAA,A, AAAA  DNS record changes to allow digicert to verify domain ownership

## 💭 Motivation and context ##

The CAA,A, AAAA  record changes are required by digicert to create SSL certificates



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] Digicert was able to verify domain ownership as a result of the DNS record additions


