### PR TITLE
Replace `rules.ncats` records with a CNAME pointing to `rules.vm` subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_MX](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_SPF](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.root_acm_rules_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_dev_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_dev_piv_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_dev_piv_acme_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -130,8 +129,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.rsaa_stage_piv_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rsaa_stage_piv_acme_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.rules_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.rules_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.rules_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_ready_set_cyber_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vincent_dev_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/acm_rules_vm.tf
+++ b/acm_rules_vm.tf
@@ -5,8 +5,11 @@
 resource "aws_acm_certificate" "rules" {
   provider = aws.acmresourcechange
 
-  domain_name       = "rules.vm.cyber.dhs.gov"
-  validation_method = "DNS"
+  domain_name = "rules.vm.cyber.dhs.gov"
+  # Include the legacy subdomain as a SAN so that requests to it are also
+  # covered by the certificate.
+  subject_alternative_names = ["rules.ncats.cyber.dhs.gov"]
+  validation_method         = "DNS"
 
   lifecycle {
     create_before_destroy = true

--- a/route53_rules_app.tf
+++ b/route53_rules_app.tf
@@ -1,43 +1,15 @@
 # ------------------------------------------------------------------------------
-# Resource records that support the Rules cloudfront endpoints and application.
+# This CNAME record directs any requests for the legacy rules.ncats subdomain to
+# the current rules.vm subdomain.  Note that DNS for the rules.vm subdomain is
+# handled in cisagov/publish-egress-ip-terraform.
 # ------------------------------------------------------------------------------
 
-# This record gives Amazon Certificate Manager permission to
-# generate certificates for rules.ncats.cyber.dhs.gov
-resource "aws_route53_record" "root_acm_rules_CNAME" {
+resource "aws_route53_record" "rules_ncats_CNAME" {
   provider = aws.route53resourcechange
 
-  name = "_724d852f42d6b10ed1c6ab4135301ef6.rules.ncats.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = [
-    "_548e9cb4a195b3c2a5410a9ff88fcda3.acm-validations.aws",
-  ]
-  ttl     = 60
+  name    = "rules.ncats.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["rules.vm.${aws_route53_zone.cyber_dhs_gov.name}"]
+  ttl     = 300
   type    = "CNAME"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "rules_ncats_A" {
-  provider = aws.route53resourcechange
-
-  alias {
-    name                   = "d35iq78wt3hgdh.cloudfront.net."
-    evaluate_target_health = false
-    zone_id                = "Z2FDTNDATAQYW2"
-  }
-  name    = "rules.ncats.${aws_route53_zone.cyber_dhs_gov.name}"
-  type    = "A"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
-resource "aws_route53_record" "rules_ncats_AAAA" {
-  provider = aws.route53resourcechange
-
-  alias {
-    name                   = "d35iq78wt3hgdh.cloudfront.net."
-    evaluate_target_health = false
-    zone_id                = "Z2FDTNDATAQYW2"
-  }
-  name    = "rules.ncats.${aws_route53_zone.cyber_dhs_gov.name}"
-  type    = "AAAA"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes DNS records related to the legacy `rules.ncats` subdomain and replaces them with a single CNAME record pointing to the `rules.vm` subdomain.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves https://github.com/cisagov/cyhy_amis/issues/309.

Note that DNS for the `rules.vm` subdomain is handled in [`cisagov/publish-egress-ip-terraform`](https://github.com/cisagov/publish-egress-ip-terraform).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I have successfully applied these changes and confirmed that `dig` returns the expected results:

```
❱ dig rules.ncats.cyber.dhs.gov

; <<>> DiG 9.10.6 <<>> rules.ncats.cyber.dhs.gov
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 6432
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;rules.ncats.cyber.dhs.gov.	IN	A

;; ANSWER SECTION:
rules.ncats.cyber.dhs.gov. 263	IN	CNAME	rules.vm.cyber.dhs.gov.
rules.vm.cyber.dhs.gov.	23	IN	A	99.84.208.76
rules.vm.cyber.dhs.gov.	23	IN	A	99.84.208.94
rules.vm.cyber.dhs.gov.	23	IN	A	99.84.208.18
rules.vm.cyber.dhs.gov.	23	IN	A	99.84.208.64

;; Query time: 0 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Fri May 31 16:24:22 EDT 2024
;; MSG SIZE  rcvd: 154
```
 
> [!NOTE]
> https://rules.ncats.cyber.dhs.gov will continue to return the legacy information until the Cloudfront distribution (and the rest of the resources in `cisagov/cyhy_amis/terraform_egress_pub`) has been torn down (see "Post-merge checklist" below).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##
- [x] `terraform destroy` resources in [`cisagov/cyhy_amis/terraform_egress_pub`](https://github.com/cisagov/cyhy_amis/tree/develop/terraform_egress_pub)
- [x] Verify that https://rules.ncats.cyber.dhs.gov returns the same content as https://rules.vm.cyber.dhs.gov
