### PR TITLE
Create dev and staging DNS resources for VINCE-NT application

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.rules_ncats_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_ready_set_cyber_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.vincent_dev_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.vincent_stage_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vip_ncats_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vpn_ncats_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.wildcard_report_dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/route53_vincent_app.tf
+++ b/route53_vincent_app.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "vincent_dev_CNAME" {
 resource "aws_route53_record" "vincent_stage_CNAME" {
   provider = aws.route53resourcechange
 
-  name    = "vincent.rsaa.${aws_route53_zone.cyber_dhs_gov.name}"
+  name    = "staging.vincent.${aws_route53_zone.cyber_dhs_gov.name}"
   records = ["vincent-stage-1522298475.us-gov-west-1.elb.amazonaws.com"]
   ttl     = 300
   type    = "CNAME"

--- a/route53_vincent_app.tf
+++ b/route53_vincent_app.tf
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------------
+# Resource records that support VINCE-NT (Vulnerability Information and
+# Coordination Environment - New Technology)
+
+# ------------------------------------------------------------------------------
+# Development entries
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "vincent_dev_CNAME" {
+  provider = aws.route53resourcechange
+
+  name    = "dev.vincent.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["vincent-dev-13498182.us-gov-west-1.elb.amazonaws.com"]
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+# ------------------------------------------------------------------------------
+# Staging entries
+# ------------------------------------------------------------------------------
+
+resource "aws_route53_record" "vincent_stage_CNAME" {
+  provider = aws.route53resourcechange
+
+  name    = "vincent.rsaa.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = ["vincent-stage-1522298475.us-gov-west-1.elb.amazonaws.com"]
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+

--- a/route53_vincent_app.tf
+++ b/route53_vincent_app.tf
@@ -29,5 +29,3 @@ resource "aws_route53_record" "vincent_stage_CNAME" {
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
-
-


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add DNS entries for the development and staging environments for VINCE-NT.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

VINCE-NT (Vulnerablity Information and Coordination Enviornment -
New Technology) is an application being moved over to CISA, which was
formerly hosted by Analygence.  DNS entries are required to access the
development and staging platforms being hosted in Mission Engineering's
Landing Zone.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

After the DNS records are created, a tool like dig will be used to verify
the records.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
