### PR TITLE
Add DNS TXT and CAA record for staging-cd crossfeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements ##
+## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers ##
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules ##
+## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources ##
+## Resources
 
 | Name | Type |
 |------|------|
@@ -117,6 +117,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.readysetcyber_cd_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -166,7 +167,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs ##
+## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -186,7 +187,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs ##
+## Outputs
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ zone.  This role has a trust relationship with the users account.
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers ##
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -94,6 +94,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_staging_cd_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_cd_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_api_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_api_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_api_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.readysetcyber_cd_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.ready_set_cyber_cd_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+## Requirements ##
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers
+## Providers ##
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules
+## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources
+## Resources ##
 
 | Name | Type |
 |------|------|
@@ -167,7 +167,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs
+## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -187,7 +187,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs
+## Outputs ##
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record._dmarc_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_crossfeed_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.api_crossfeed_staging_digicert_letsencrypt_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_ready_set_cyber_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_ready_set_cyber_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements ##
+## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers ##
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -31,13 +31,13 @@ zone.  This role has a trust relationship with the users account.
 | aws.route53resourcechange | ~> 4.9 |
 | terraform | n/a |
 
-## Modules ##
+## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
-## Resources ##
+## Resources
 
 | Name | Type |
 |------|------|
@@ -67,6 +67,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.api_staging_ready_set_cyber_staging_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.api_staging_ready_set_cyber_staging_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ceil_NS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_api_staging_cd_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -166,7 +167,7 @@ zone.  This role has a trust relationship with the users account.
 | [terraform_remote_state.pca_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
-## Inputs ##
+## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -186,7 +187,7 @@ zone.  This role has a trust relationship with the users account.
 | sessendemail\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to send email via AWS SES. | `string` | `"SesSendEmail-cyber.dhs.gov"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
-## Outputs ##
+## Outputs
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ zone.  This role has a trust relationship with the users account.
 | terraform | ~> 1.0 |
 | aws | ~> 4.9 |
 
-## Providers
+## Providers ##
 
 | Name | Version |
 |------|---------|

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.crossfeed_staging_cd_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_cd_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.crossfeed_staging_digicert_letsencrypt_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim1_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim2_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.crossfeed_staging_dkim3_CNAME](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+## Requirements ##
 
 | Name | Version |
 |------|---------|

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ zone.  This role has a trust relationship with the users account.
 1. Run the command `terraform apply`.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements ##
+## Requirements
 
 | Name | Version |
 |------|---------|
@@ -117,7 +117,6 @@ zone.  This role has a trust relationship with the users account.
 | [aws_route53_record.ready_set_cyber_prod_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_prod_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.ready_set_cyber_staging_digicert_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.readysetcyber_cd_acme_TXT](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_A](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_AAAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.root_CAA](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -278,6 +278,18 @@ resource "aws_route53_record" "crossfeed_staging_MX" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "crossfeed_api_staging_cd_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "VwhWkk45liHDBwHyCYmgWPJBISgphbZvtnPkkctyDrw",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 resource "aws_route53_record" "crossfeed_staging_TXT" {
   provider = aws.route53resourcechange
 

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -343,7 +343,7 @@ resource "aws_route53_record" "crossfeed_api_staging_cd_TXT" {
 
   name = "_acme-challenge.api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "VwhWkk45liHDBwHyCYmgWPJBISgphbZvtnPkkctyDrw",
+    "oAKlQzzXD40dDvl-D-qkoPHvrRiUudyexsv7_790944",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -368,7 +368,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_TXT" {
 
   name = "_acme-challenge.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "UP9T-qKgSPz6ivcU1lRtbnI_vfly8lk8ZKTkbfya3Wo",
+    "1B3S1njjEMfEM3bZZByZSqw3L_FFOrzlUoWF3DCEY4k",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -182,7 +182,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d-6duqftvveb.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
     evaluate_target_health = false
     zone_id                = var.api_gateway_zone_id
   }
@@ -195,7 +195,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d-6duqftvveb.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
     evaluate_target_health = false
     zone_id                = var.api_gateway_zone_id
   }

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -363,6 +363,18 @@ resource "aws_route53_record" "api_crossfeed_staging_digicert_letsencrypt_CAA" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "crossfeed_staging_cd_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "UP9T-qKgSPz6ivcU1lRtbnI_vfly8lk8ZKTkbfya3Wo",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 # The hosted_zone_id for the below records comes from https://docs.aws.amazon.com/general/latest/gr/elb.html
 # (ALBs in us-gov-west-1 region)
 resource "aws_route53_record" "crossfeed_staging_api_A" {

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -282,18 +282,6 @@ resource "aws_route53_record" "crossfeed_staging_MX" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
-resource "aws_route53_record" "crossfeed_api_staging_cd_TXT" {
-  provider = aws.route53resourcechange
-
-  name = "_acme-challenge.api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = [
-    "VwhWkk45liHDBwHyCYmgWPJBISgphbZvtnPkkctyDrw",
-  ]
-  ttl     = 3000
-  type    = "TXT"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
 resource "aws_route53_record" "crossfeed_staging_TXT" {
   provider = aws.route53resourcechange
 
@@ -347,6 +335,31 @@ resource "aws_route53_record" "crossfeed_staging_cd_api_AAAA" {
   }
   name    = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   type    = "AAAA"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "crossfeed_api_staging_cd_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "VwhWkk45liHDBwHyCYmgWPJBISgphbZvtnPkkctyDrw",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
+resource "aws_route53_record" "api_crossfeed_staging_digicert_letsencrypt_CAA" {
+  provider = aws.route53resourcechange
+
+  name = "api.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "0 issue \"digicert.com\"",
+    "0 issue \"letsencrypt.org\"",
+  ]
+  ttl     = 3600
+  type    = "CAA"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -182,7 +182,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_A" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-6duqftvveb.execute-api.us-east-1.amazonaws.com."
     evaluate_target_health = false
     zone_id                = var.api_gateway_zone_id
   }
@@ -195,7 +195,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_AAAA" {
   provider = aws.route53resourcechange
 
   alias {
-    name                   = "d-0yk2b6imci.execute-api.us-east-1.amazonaws.com."
+    name                   = "d-6duqftvveb.execute-api.us-east-1.amazonaws.com."
     evaluate_target_health = false
     zone_id                = var.api_gateway_zone_id
   }

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -368,7 +368,7 @@ resource "aws_route53_record" "crossfeed_staging_cd_TXT" {
 
   name = "_acme-challenge.staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
   records = [
-    "1B3S1njjEMfEM3bZZByZSqw3L_FFOrzlUoWF3DCEY4k",
+    "S9yJvnXVz1J6WL__0Lf12au-baP1gWBLm8Gi_hbcJ28",
   ]
   ttl     = 3000
   type    = "TXT"

--- a/route53_crossfeed_app.tf
+++ b/route53_crossfeed_app.tf
@@ -375,6 +375,19 @@ resource "aws_route53_record" "crossfeed_staging_cd_TXT" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "crossfeed_staging_digicert_letsencrypt_CAA" {
+  provider = aws.route53resourcechange
+
+  name = "staging-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "0 issue \"digicert.com\"",
+    "0 issue \"letsencrypt.org\"",
+  ]
+  ttl     = 3600
+  type    = "CAA"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 # The hosted_zone_id for the below records comes from https://docs.aws.amazon.com/general/latest/gr/elb.html
 # (ALBs in us-gov-west-1 region)
 resource "aws_route53_record" "crossfeed_staging_api_A" {

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -46,18 +46,6 @@ resource "aws_route53_record" "ready_set_cyber_prod_AAAA" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
-resource "aws_route53_record" "readysetcyber_cd_acme_TXT" {
-  provider = aws.route53resourcechange
-
-  name = "_acme-challenge.readysetcyber-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = [
-    "5GFu45J8DveOcUvkRgvFhGSXHho4eMMaR_-qtPQG4rw",
-  ]
-  ttl     = 3000
-  type    = "TXT"
-  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
-}
-
 
 
 # ------------------------------------------------------------------------------

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -46,7 +46,7 @@ resource "aws_route53_record" "ready_set_cyber_prod_AAAA" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
-resource "aws_route53_record" "readysetcyber_cd_acme_TXT" {
+resource "aws_route53_record" "ready_set_cyber_cd_acme_TXT" {
   provider = aws.route53resourcechange
 
   name = "_acme-challenge.readysetcyber-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"

--- a/route53_readysetcyber_app.tf
+++ b/route53_readysetcyber_app.tf
@@ -46,6 +46,18 @@ resource "aws_route53_record" "ready_set_cyber_prod_AAAA" {
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
 }
 
+resource "aws_route53_record" "readysetcyber_cd_acme_TXT" {
+  provider = aws.route53resourcechange
+
+  name = "_acme-challenge.readysetcyber-cd.crossfeed.${aws_route53_zone.cyber_dhs_gov.name}"
+  records = [
+    "5GFu45J8DveOcUvkRgvFhGSXHho4eMMaR_-qtPQG4rw",
+  ]
+  ttl     = 3000
+  type    = "TXT"
+  zone_id = aws_route53_zone.cyber_dhs_gov.zone_id
+}
+
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Add DNS TXT and CAA record for staging-cd

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

We need to update the TXT and CAA record for the DNS to create a certificate for Let'sEncrypt. terraform-docs has been run.

Add/Update the crossfeed_staging_cd_TXT

## 💭 Motivation and context ##

There are no existing ACME certs

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.