### PR TITLE
Turn on Virtual Deliverability Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ zone.  This role has a trust relationship with the users account.
 
 | Name | Source | Version |
 |------|--------|---------|
-| read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | feature%2Fadd-option-for-write-permission |
+| read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
 
 ## Resources ##
 

--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ zone.  This role has a trust relationship with the users account.
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 4.9 |
+| aws | ~> 5.20 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 4.9 |
-| aws.acmresourcechange | ~> 4.9 |
-| aws.dnsprovisionaccount | ~> 4.9 |
-| aws.organizationsreadonly | ~> 4.9 |
-| aws.route53resourcechange | ~> 4.9 |
+| aws | ~> 5.20 |
+| aws.acmresourcechange | ~> 5.20 |
+| aws.dnsprovisionaccount | ~> 5.20 |
+| aws.organizationsreadonly | ~> 5.20 |
+| aws.route53resourcechange | ~> 5.20 |
 | terraform | n/a |
 
 ## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
-| read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
+| read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | feature%2Fadd-option-for-write-permission |
 
 ## Resources ##
 
@@ -150,6 +150,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_ses_identity_notification_topic.cyber_dhs_gov_bounce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
 | [aws_ses_identity_notification_topic.cyber_dhs_gov_complaint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
 | [aws_ses_identity_notification_topic.cyber_dhs_gov_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_identity_notification_topic) | resource |
+| [aws_sesv2_account_vdm_attributes.cyber_dhs_gov_vdm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sesv2_account_vdm_attributes) | resource |
 | [aws_sns_topic.cyber_dhs_gov_bounce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic.cyber_dhs_gov_complaint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic.cyber_dhs_gov_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=feature%2Fadd-option-for-write-permission"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module"
 
   providers = {
     aws = aws.terraformprovisionaccount

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 module "read_terraform_state" {
-  source = "github.com/cisagov/terraform-state-read-role-tf-module"
+  source = "github.com/cisagov/terraform-state-read-role-tf-module?ref=feature%2Fadd-option-for-write-permission"
 
   providers = {
     aws = aws.terraformprovisionaccount

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -21,6 +21,12 @@ resource "aws_route53_record" "root_CAA" {
 # Generation of the domain identity token and DKIM keys in SES.
 # ------------------------------------------------------------------------------
 
+# We should consider upgrading to aws_sesv2_email_identity, although
+# it would be a destructive upgrade:
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sesv2_email_identity
+#
+# See also
+# https://github.com/trussworks/terraform-aws-ses-domain/blob/main/main.tf
 resource "aws_ses_domain_identity" "cyhy_dhs_gov_identity" {
   provider = aws.route53resourcechange
 

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -21,12 +21,11 @@ resource "aws_route53_record" "root_CAA" {
 # Generation of the domain identity token and DKIM keys in SES.
 # ------------------------------------------------------------------------------
 
-# We should consider upgrading to aws_sesv2_email_identity, although
-# it would be a destructive upgrade:
+# TODO: Consider upgrading to aws_sesv2_email_identity, although it
+# would likely be a destructive upgrade:
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sesv2_email_identity
 #
-# See also
-# https://github.com/trussworks/terraform-aws-ses-domain/blob/main/main.tf
+# See also issue #109.
 resource "aws_ses_domain_identity" "cyhy_dhs_gov_identity" {
   provider = aws.route53resourcechange
 

--- a/route53_static.tf
+++ b/route53_static.tf
@@ -27,6 +27,25 @@ resource "aws_ses_domain_identity" "cyhy_dhs_gov_identity" {
   domain = aws_route53_zone.cyber_dhs_gov.name
 }
 
+# VDM will show us some useful information about emails that bounced,
+# such as the diagnostic code indicating the reason for the bounce.
+#
+# We don't care about the engagement metrics, since we don't care to
+# track if users click the attachments we send.
+resource "aws_sesv2_account_vdm_attributes" "cyber_dhs_gov_vdm" {
+  provider = aws.route53resourcechange
+
+  vdm_enabled = "ENABLED"
+
+  dashboard_attributes {
+    engagement_metrics = "DISABLED"
+  }
+
+  guardian_attributes {
+    optimized_shared_delivery = "ENABLED"
+  }
+}
+
 resource "aws_ses_domain_dkim" "cyber_dhs_gov_dkim" {
   provider = aws.route53resourcechange
 

--- a/route53resourcechange_policy.tf
+++ b/route53resourcechange_policy.tf
@@ -33,10 +33,12 @@ data "aws_iam_policy_document" "route53resourcechange_doc" {
   statement {
     actions = [
       "ses:DeleteIdentity",
+      "ses:GetAccount",
       "ses:GetIdentityDkimAttributes",
       "ses:GetIdentityMailFromDomainAttributes",
       "ses:GetIdentityNotificationAttributes",
       "ses:GetIdentityVerificationAttributes",
+      "ses:PutAccountVdmAttributes",
       "ses:SetIdentityHeadersInNotificationsEnabled",
       "ses:SetIdentityMailFromDomain",
       "ses:SetIdentityNotificationTopic",

--- a/sesmanagesuppressionlist_policy.tf
+++ b/sesmanagesuppressionlist_policy.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "sesmanagesuppressionlist_doc" {
   statement {
     actions = [
       "ses:DeleteSuppressedDestination",
+      "ses:GetMessageInsights",
       "ses:GetSuppressedDestination",
       "ses:ListSuppressedDestinations",
       "ses:PutAccountSuppressionAttributes",

--- a/versions.tf
+++ b/versions.tf
@@ -12,9 +12,13 @@ terraform {
     # for more information about the changes in v4.9 and
     # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     # for more information about the S3 bucket refactor.
+    #
+    # Version 5.20 of the Terraform AWS provider is the first version
+    # to offer the aws_sesv2_account_vdm_attributes resource, which we
+    # require here.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 5.20"
     }
   }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request turns on the Virtual Deliverability Manager advisor in our SES account.

## 💭 Motivation and context ##

VDM will show us some useful information about emails that bounced, such as the diagnostic code indicating the reason for the bounce.

## 🧪 Testing ##

I successfully applied these changes to our COOL DNS account.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to the default branch of [cisagov/terraform-state-read-role-tf-module](https://github.com/cisagov/terraform-state-read-role-tf-module) once cisagov/terraform-state-read-role-tf-module#37 is merged.
