### PR TITLE
update vincent dev hostname to point to cloudfront

### DIFF
--- a/route53_vincent_app.tf
+++ b/route53_vincent_app.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "vincent_dev_CNAME" {
   provider = aws.route53resourcechange
 
   name    = "dev.vincent.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["vincent-dev-13498182.us-gov-west-1.elb.amazonaws.com"]
+  records = ["dmm9ihx0h3npb.cloudfront.net"]
   ttl     = 300
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

These changes are to point the existing FQDN for VINCE-NT DEV at the test Cloudfront distribution for connectivity testing.

## 💭 Motivation and context ##

This is to support testing Cloudfront and preparing to move VINCE-NT to staging for the next steps in deployment.

## 🧪 Testing ##

Cloudfront distribution FQDN has been verified.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
