### PR TITLE
Use the correct value for the path to the Terraform state

### DIFF
--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -21,5 +21,5 @@ module "read_terraform_state" {
   create_assume_role          = false
   role_name                   = var.read_terraform_state_role_name
   terraform_state_bucket_name = "cisa-cool-terraform-state"
-  terraform_state_path        = "cool-dns-cyber.dhs.gov/*.tfstate"
+  terraform_state_path        = "cool-dns-cyber.dhs.gov.tfstate"
 }


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes a small, but important update to the path of the Terraform state for this repo in the IAM policy that allows access to that state data.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It's not clear if this path was always incorrect or if it used to be correct and Terraform has since changed their path format.  Either way, this is how it should look now.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

After applying this change, I confirmed that I was able to assume the role and read the state data as intended.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

