### PR TITLE
Allow additional accounts to assume route53 change role

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ zone.  This role has a trust relationship with the users account.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.acmresourcechange_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.route53resourcechange_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.route53resourcechange_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sesmanagesuppressionlist_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sesmanagesuppressionlist_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -183,6 +184,7 @@ zone.  This role has a trust relationship with the users account.
 | acmresourcechange\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"Allows sufficient permissions to modify ACM resources in the DNS account."` | no |
 | acmresourcechange\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to modify ACM (AWS Certificate Manager) resources in the DNS account. | `string` | `"ACMResourceChange"` | no |
 | additional\_remote\_state\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to read this root module's remote state (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
+| additional\_route53\_resource\_change\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to create and modify resource records in the cyber.dhs.gov zone (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | additional\_ses\_sendemail\_account\_ids | A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. ["123456789012"]). | `list(string)` | `[]` | no |
 | api\_gateway\_zone\_id | The Route 53 hosted zone ID for API gateways. | `string` | `"Z1UJRXOUMOOFQ8"` | no |
 | aws\_region | The AWS region to communicate with. | `string` | `"us-east-1"` | no |

--- a/route53resourcechange_role.tf
+++ b/route53resourcechange_role.tf
@@ -3,10 +3,33 @@
 # resource records in the DNS zone.
 # ------------------------------------------------------------------------------
 
+# An IAM policy document that allows the Users account and any
+# additionally-specified accounts to assume the role.
+data "aws_iam_policy_document" "route53resourcechange_assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      # Account usage needs:
+      # - Additional: The use case for each account should be documented with
+      #   a comment in the Terraform variables file
+      # - Users: Ongoing maintenance of the cyber.dhs.gov zone
+      identifiers = concat(
+        var.additional_route53_resource_change_account_ids,
+        [local.users_account_id]
+      )
+      type = "AWS"
+    }
+  }
+}
+
 resource "aws_iam_role" "route53resourcechange_role" {
   provider = aws.dnsprovisionaccount
 
-  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  assume_role_policy = data.aws_iam_policy_document.route53resourcechange_assume_role_doc.json
   description        = var.route53resourcechange_role_description
   name               = var.route53resourcechange_role_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,13 @@ variable "additional_remote_state_account_ids" {
   type        = list(string)
 }
 
+variable "additional_route53_resource_change_account_ids" {
+  default     = []
+  description = "A list of account IDs corresponding to additional accounts that should have permission to assume the role to create and modify resource records in the cyber.dhs.gov zone (e.g. [\"123456789012\"])."
+  nullable    = false
+  type        = list(string)
+}
+
 variable "additional_ses_sendemail_account_ids" {
   default     = []
   description = "A list of account IDs corresponding to additional accounts that should have permission to assume the role to send email via AWS SES (e.g. [\"123456789012\"])."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the trust policy for the `route53resourcechange_role` so that additional AWS accounts can optionally be allowed to assume it.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This functionality is necessary for other COOL environments (e.g. dev and staging) to modify DNS records in this zone.

A potential future improvement (suggested by @jsf9k) is to delegate access to COOL subdomains via DNS zones owned by each environment, but until then, this solution should hopefully suffice.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied these changes and allowed our dev and staging accounts to assume the `route53resourcechange_role`.  So far, everything appears to be working as expected (I can see that my dev account user was able to successfully assume the role).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
