### PR TITLE
update cloudfront distribution for vince-nt dev

### DIFF
--- a/route53_vincent_app.tf
+++ b/route53_vincent_app.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "vincent_dev_CNAME" {
   provider = aws.route53resourcechange
 
   name    = "dev.vincent.${aws_route53_zone.cyber_dhs_gov.name}"
-  records = ["dmm9ihx0h3npb.cloudfront.net"]
+  records = ["d2spp3lrnt0s7j.cloudfront.net"]
   ttl     = 300
   type    = "CNAME"
   zone_id = aws_route53_zone.cyber_dhs_gov.zone_id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR changes the target of the VINCE-NT dev hostname to point to an updated Cloudfront distribution.

## 💭 Motivation and context ##

This change is required for continued development of the VINCE-NT platform as it moves towards test/staging. 

## 🧪 Testing ##

N/A

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
