### PR TITLE
Add a comment explaining why a Terraform state bucket name is hard-coded

### DIFF
--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -18,8 +18,10 @@ module "read_terraform_state" {
     local.users_account_id
   ], var.additional_remote_state_account_ids))
   # Don't create the assume role policy
-  create_assume_role          = false
-  role_name                   = var.read_terraform_state_role_name
+  create_assume_role = false
+  role_name          = var.read_terraform_state_role_name
+  # There is only one currently-supported bucket for this remote state, so we
+  # must use it.
   terraform_state_bucket_name = "cisa-cool-terraform-state"
   terraform_state_path        = "cool-dns-cyber.dhs.gov.tfstate"
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR simply adds comment explaining why a Terraform state bucket name is hard-coded.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As we make updates to COOL repositories in support of multiple environments (dev, staging, production, etc.) we aim to eliminate all instances of hard-coded bucket names in our code, however that is not preferable in this particular case.  This comment should've been added in #126, but it was overlooked.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

None needed.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

